### PR TITLE
General bugs and cleanup.

### DIFF
--- a/src/app/s3.rs
+++ b/src/app/s3.rs
@@ -1,7 +1,7 @@
 use aws_sdk_s3::{error::SdkError, operation::head_bucket::HeadBucketError};
 use bytes::{Bytes, BytesMut};
 
-use crate::models::error::AppError;
+use crate::models::{document::Document, error::AppError};
 
 use super::application::{ApplicationState, S3Client};
 
@@ -129,23 +129,23 @@ impl S3Service {
     ///
     /// ## Arguments
     ///
-    /// - `document_path`: The built path of the document.
-    /// - `data`: The data of the document.
+    /// - `document`: The [`Document`].
+    /// - `content`: The content of the document.
     ///
     /// ## Errors
     ///
     /// - [`AppError`] - When the document could not be created.
     pub async fn create_document(
         &self,
-        document_path: String,
-        data: Bytes,
+        document: &Document,
+        content: Bytes,
     ) -> Result<(), AppError> {
         self.client
             .put_object()
             .bucket(self.document_bucket_name())
-            .content_type("text/plain")
-            .key(document_path)
-            .body(data.into())
+            .content_type(document.document_type.clone())
+            .key(document.generate_path())
+            .body(content.into())
             .send()
             .await?;
 

--- a/src/models/authentication.rs
+++ b/src/models/authentication.rs
@@ -65,9 +65,9 @@ impl Token {
         .await?)
     }
 
-    /// Update.
+    /// Insert.
     ///
-    /// Create a paste token.
+    /// Insert (create) a paste token.
     ///
     /// ## Arguments
     ///
@@ -75,8 +75,8 @@ impl Token {
     ///
     /// ## Errors
     ///
-    /// - [`AppError`] - The database had an error.
-    pub async fn update(&self, transaction: &mut PgTransaction<'_>) -> Result<(), AppError> {
+    /// - [`AppError`] - The database had an error, or the snowflake exists already.
+    pub async fn insert(&self, transaction: &mut PgTransaction<'_>) -> Result<(), AppError> {
         let paste_id: i64 = self.paste_id.into();
         sqlx::query!(
             "INSERT INTO paste_tokens(paste_id, token) VALUES ($1, $2)",

--- a/src/models/document.rs
+++ b/src/models/document.rs
@@ -147,9 +147,7 @@ impl Document {
     /// ## Errors
     ///
     /// - [`AppError`] - The database had an error, or the snowflake exists already.
-    pub async fn insert(
-        &self, transaction: &mut PgTransaction<'_>
-    ) -> Result<(), AppError> {
+    pub async fn insert(&self, transaction: &mut PgTransaction<'_>) -> Result<(), AppError> {
         let document_id: i64 = self.id.into();
         let paste_id: i64 = self.paste_id.into();
 
@@ -159,7 +157,9 @@ impl Document {
             paste_id,
             self.document_type,
             self.name
-        ).execute(transaction.as_mut()).await?;
+        )
+        .execute(transaction.as_mut())
+        .await?;
 
         Ok(())
     }

--- a/src/models/document.rs
+++ b/src/models/document.rs
@@ -136,6 +136,34 @@ impl Document {
         Ok(documents)
     }
 
+    /// Insert.
+    ///
+    /// Insert (create) a document.
+    ///
+    /// ## Arguments
+    ///
+    /// - `transaction` The transaction to use.
+    ///
+    /// ## Errors
+    ///
+    /// - [`AppError`] - The database had an error, or the snowflake exists already.
+    pub async fn insert(
+        &self, transaction: &mut PgTransaction<'_>
+    ) -> Result<(), AppError> {
+        let document_id: i64 = self.id.into();
+        let paste_id: i64 = self.paste_id.into();
+
+        sqlx::query!(
+            "INSERT INTO documents(id, paste_id, type, name) VALUES ($1, $2, $3, $4)",
+            document_id,
+            paste_id,
+            self.document_type,
+            self.name
+        ).execute(transaction.as_mut()).await?;
+
+        Ok(())
+    }
+
     /// Update.
     ///
     /// Create (or update) a document.

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -2,4 +2,5 @@ pub mod authentication;
 pub mod document;
 pub mod error;
 pub mod paste;
+pub mod payload;
 pub mod snowflake;

--- a/src/models/paste.rs
+++ b/src/models/paste.rs
@@ -116,6 +116,32 @@ impl Paste {
         Ok(pastes)
     }
 
+    /// Insert.
+    ///
+    /// Insert (create) a paste.
+    ///
+    /// ## Arguments
+    ///
+    /// - `transaction` The transaction to use.
+    ///
+    /// ## Errors
+    ///
+    /// - [`AppError`] - The database had an error, or the snowflake exists already.
+    pub async fn insert(
+        &self, transaction: &mut PgTransaction<'_>
+    ) -> Result<(), AppError> {
+        let paste_id: i64 = self.id.into();
+
+        sqlx::query!(
+            "INSERT INTO pastes(id, edited, expiry) VALUES ($1, $2, $3)",
+            paste_id,
+            self.edited,
+            self.expiry
+        ).execute(transaction.as_mut()).await?;
+
+        Ok(())
+    }
+
     /// Update.
     ///
     /// Create (or update) a document.

--- a/src/models/paste.rs
+++ b/src/models/paste.rs
@@ -127,9 +127,7 @@ impl Paste {
     /// ## Errors
     ///
     /// - [`AppError`] - The database had an error, or the snowflake exists already.
-    pub async fn insert(
-        &self, transaction: &mut PgTransaction<'_>
-    ) -> Result<(), AppError> {
+    pub async fn insert(&self, transaction: &mut PgTransaction<'_>) -> Result<(), AppError> {
         let paste_id: i64 = self.id.into();
 
         sqlx::query!(
@@ -137,7 +135,9 @@ impl Paste {
             paste_id,
             self.edited,
             self.expiry
-        ).execute(transaction.as_mut()).await?;
+        )
+        .execute(transaction.as_mut())
+        .await?;
 
         Ok(())
     }

--- a/src/models/payload.rs
+++ b/src/models/payload.rs
@@ -1,0 +1,153 @@
+use secrecy::ExposeSecret;
+use serde::{Deserialize, Serialize};
+
+use super::{authentication::Token, document::Document, paste::Paste, snowflake::Snowflake};
+
+#[derive(Deserialize)]
+pub struct IncludeContentQuery {
+    /// Whether to return the content(s) of the document(s).
+    ///
+    /// Defaults to False.
+    #[serde(default, rename = "content")]
+    pub include_content: bool,
+}
+
+pub type GetPasteQuery = IncludeContentQuery;
+
+pub type PostPasteQuery = IncludeContentQuery;
+
+#[derive(Deserialize)]
+pub struct MultiplePastesBody {
+    /// The ID's to use.
+    pub ids: Vec<Snowflake>,
+}
+
+pub type GetPastesBody = MultiplePastesBody;
+
+pub type DeletePastesBody = MultiplePastesBody;
+
+#[derive(Deserialize)]
+pub struct PostPasteBody {
+    /// The expiry time for the paste.
+    #[serde(default)]
+    pub expiry: Option<usize>,
+}
+
+#[derive(Serialize)]
+pub struct ResponsePaste {
+    /// The ID for the paste.
+    pub id: Snowflake,
+    /// The token attached to the paste.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub token: Option<String>,
+    /// Whether the paste has been edited.
+    pub edited: bool,
+    /// The expiry time of the paste.
+    pub expiry: Option<usize>,
+    /// The documents attached to the paste.
+    pub documents: Vec<ResponseDocument>,
+}
+
+impl ResponsePaste {
+    /// New.
+    ///
+    /// Create a new [`ResponsePaste`] object.
+    pub const fn new(
+        id: Snowflake,
+        token: Option<String>,
+        edited: bool,
+        expiry: Option<usize>,
+        documents: Vec<ResponseDocument>,
+    ) -> Self {
+        Self {
+            id,
+            token,
+            edited,
+            expiry,
+            documents,
+        }
+    }
+
+    /// From Paste.
+    ///
+    /// Create a new [`ResponsePaste`] from a [`Paste`] and [`ResponseDocument`]'s
+    ///
+    /// ## Arguments
+    ///
+    /// - `paste` - The paste to extract from.
+    /// - `token` - The token to use (if provided).
+    /// - `documents` - The documents to attach.
+    ///
+    /// ## Returns
+    ///
+    /// The [`ResponsePaste`].
+    pub fn from_paste(
+        paste: &Paste,
+        token: Option<Token>,
+        documents: Vec<ResponseDocument>,
+    ) -> Self {
+        let token_value: Option<String> = { token.map(|t| t.token().expose_secret().to_string()) };
+
+        let expiry = paste.expiry.map(|v| v.unix_timestamp() as usize);
+
+        Self::new(paste.id, token_value, paste.edited, expiry, documents)
+    }
+}
+
+#[derive(Serialize)]
+pub struct ResponseDocument {
+    /// The ID for the document.
+    pub id: Snowflake,
+    /// The paste ID the document is attached too.
+    pub paste_id: Snowflake,
+    /// The type of document.
+    #[serde(rename = "type")]
+    pub document_type: String,
+    /// The name of the document.
+    pub name: String,
+    /// The content of the document.
+    pub content: Option<String>,
+}
+
+impl ResponseDocument {
+    /// New.
+    ///
+    /// Create a new [`ResponseDocument`] object.
+    pub const fn new(
+        id: Snowflake,
+        paste_id: Snowflake,
+        document_type: String,
+        name: String,
+        content: Option<String>,
+    ) -> Self {
+        Self {
+            id,
+            paste_id,
+            document_type,
+            name,
+            content,
+        }
+    }
+
+    /// From Document.
+    ///
+    /// Create a new [`ResponseDocument`] from a [`Document`] and its content.
+    ///
+    /// ## Arguments
+    ///
+    /// - `document` - The document to extract from.
+    /// - `content` - The content to use (if provided).
+    ///
+    /// ## Returns
+    ///
+    /// The [`ResponseDocument`].
+    pub fn from_document(document: Document, content: Option<String>) -> Self {
+        Self::new(
+            document.id,
+            document.paste_id,
+            document.document_type,
+            document.name,
+            content,
+        )
+    }
+}

--- a/src/models/payload.rs
+++ b/src/models/payload.rs
@@ -17,16 +17,6 @@ pub type GetPasteQuery = IncludeContentQuery;
 pub type PostPasteQuery = IncludeContentQuery;
 
 #[derive(Deserialize)]
-pub struct MultiplePastesBody {
-    /// The ID's to use.
-    pub ids: Vec<Snowflake>,
-}
-
-pub type GetPastesBody = MultiplePastesBody;
-
-pub type DeletePastesBody = MultiplePastesBody;
-
-#[derive(Deserialize)]
 pub struct PostPasteBody {
     /// The expiry time for the paste.
     #[serde(default)]

--- a/src/rest/paste.rs
+++ b/src/rest/paste.rs
@@ -343,7 +343,7 @@ async fn post_paste(
 
     let paste = Paste::new(paste_id, false, expiry);
 
-    paste.update(&mut transaction).await?;
+    paste.insert(&mut transaction).await?;
 
     let mut documents: Vec<(Document, String)> = Vec::new();
     while let Some(field) = multipart.next_field().await? {
@@ -401,14 +401,12 @@ async fn post_paste(
     for (document, content) in documents {
         app.s3.create_document(&document, content.into()).await?;
 
-        document.update(&mut transaction).await?;
+        document.insert(&mut transaction).await?;
     }
-
-    paste.update(&mut transaction).await?;
 
     let paste_token = Token::new(paste_id, generate_token(paste_id)?);
 
-    paste_token.update(&mut transaction).await?;
+    paste_token.insert(&mut transaction).await?;
 
     transaction.commit().await?;
 

--- a/src/rest/paste.rs
+++ b/src/rest/paste.rs
@@ -8,8 +8,6 @@ use axum::{
     routing::{delete, get, patch, post},
 };
 use regex::Regex;
-use secrecy::ExposeSecret;
-use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
 use tower_governor::{GovernorLayer, governor::GovernorConfigBuilder};
 
@@ -20,6 +18,10 @@ use crate::{
         document::Document,
         error::{AppError, AuthError},
         paste::Paste,
+        payload::{
+            GetPasteQuery, GetPastesBody, PostPasteBody, PostPasteQuery, ResponseDocument,
+            ResponsePaste,
+        },
         snowflake::Snowflake,
     },
 };
@@ -220,7 +222,7 @@ async fn get_pastes(
 ) -> Result<Response, AppError> {
     let mut response_pastes: Vec<ResponsePaste> = Vec::new();
 
-    for paste_id in body.paste_ids {
+    for paste_id in body.ids {
         let paste = Paste::fetch(&app.database, paste_id)
             .await?
             .ok_or_else(|| AppError::NotFound("Paste not found.".to_string()))?;
@@ -454,162 +456,6 @@ async fn delete_paste(
     Paste::delete_with_id(&app.database, paste_id).await?;
 
     Ok(StatusCode::NO_CONTENT.into_response())
-}
-
-#[derive(Deserialize, Serialize)]
-pub struct GetPasteQuery {
-    /// Whether to return the content(s) of the documents.
-    ///
-    /// Defaults to False.
-    #[serde(default, rename = "content")]
-    pub include_content: bool,
-}
-
-#[derive(Deserialize, Serialize)]
-pub struct GetPastesBody {
-    /// The ID's to get.
-    pub paste_ids: Vec<Snowflake>,
-}
-
-#[derive(Deserialize, Serialize)]
-pub struct PostPasteQuery {
-    /// Whether to return the content(s) of the documents.
-    ///
-    /// Defaults to false.
-    #[serde(default, rename = "content")]
-    pub include_content: bool,
-}
-
-#[derive(Deserialize, Serialize)]
-pub struct PostPasteBody {
-    /// The expiry time for the paste.
-    #[serde(default)]
-    pub expiry: Option<usize>,
-}
-
-#[derive(Deserialize, Serialize)]
-pub struct DeletePastesBody {
-    /// The ID's to get.
-    pub ids: Vec<Snowflake>,
-}
-
-#[derive(Deserialize, Serialize)]
-pub struct ResponsePaste {
-    /// The ID for the paste.
-    pub id: Snowflake,
-    /// The token attached to the paste.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub token: Option<String>,
-    /// Whether the paste has been edited.
-    pub edited: bool,
-    /// The expiry time of the paste.
-    pub expiry: Option<usize>,
-    /// The documents attached to the paste.
-    pub documents: Vec<ResponseDocument>,
-}
-
-impl ResponsePaste {
-    /// New.
-    ///
-    /// Create a new [`ResponsePaste`] object.
-    pub const fn new(
-        id: Snowflake,
-        token: Option<String>,
-        edited: bool,
-        expiry: Option<usize>,
-        documents: Vec<ResponseDocument>,
-    ) -> Self {
-        Self {
-            id,
-            token,
-            edited,
-            expiry,
-            documents,
-        }
-    }
-
-    /// From Paste.
-    ///
-    /// Create a new [`ResponsePaste`] from a [`Paste`] and [`ResponseDocument`]'s
-    ///
-    /// ## Arguments
-    ///
-    /// - `paste` - The paste to extract from.
-    /// - `token` - The token to use (if provided).
-    /// - `documents` - The documents to attach.
-    ///
-    /// ## Returns
-    ///
-    /// The [`ResponsePaste`].
-    pub fn from_paste(
-        paste: &Paste,
-        token: Option<Token>,
-        documents: Vec<ResponseDocument>,
-    ) -> Self {
-        let token_value: Option<String> = { token.map(|t| t.token().expose_secret().to_string()) };
-
-        let expiry = paste.expiry.map(|v| v.unix_timestamp() as usize);
-
-        Self::new(paste.id, token_value, paste.edited, expiry, documents)
-    }
-}
-
-#[derive(Deserialize, Serialize)]
-pub struct ResponseDocument {
-    /// The ID for the document.
-    pub id: Snowflake,
-    /// The paste ID the document is attached too.
-    pub paste_id: Snowflake,
-    /// The type of document.
-    #[serde(rename = "type")]
-    pub document_type: String,
-    /// The name of the document.
-    pub name: String,
-    /// The content of the document.
-    pub content: Option<String>,
-}
-
-impl ResponseDocument {
-    /// New.
-    ///
-    /// Create a new [`ResponseDocument`] object.
-    pub const fn new(
-        id: Snowflake,
-        paste_id: Snowflake,
-        document_type: String,
-        name: String,
-        content: Option<String>,
-    ) -> Self {
-        Self {
-            id,
-            paste_id,
-            document_type,
-            name,
-            content,
-        }
-    }
-
-    /// From Document.
-    ///
-    /// Create a new [`ResponseDocument`] from a [`Document`] and its content.
-    ///
-    /// ## Arguments
-    ///
-    /// - `document` - The document to extract from.
-    /// - `content` - The content to use (if provided).
-    ///
-    /// ## Returns
-    ///
-    /// The [`ResponseDocument`].
-    pub fn from_document(document: Document, content: Option<String>) -> Self {
-        Self::new(
-            document.id,
-            document.paste_id,
-            document.document_type,
-            document.name,
-            content,
-        )
-    }
 }
 
 // FIXME: This whole function needs rebuilding. I do not like the way its made.

--- a/src/rest/paste.rs
+++ b/src/rest/paste.rs
@@ -19,7 +19,7 @@ use crate::{
         error::{AppError, AuthError},
         paste::Paste,
         payload::{
-            GetPasteQuery, GetPastesBody, PostPasteBody, PostPasteQuery, ResponseDocument,
+            GetPasteQuery, PostPasteBody, PostPasteQuery, ResponseDocument,
             ResponsePaste,
         },
         snowflake::Snowflake,
@@ -218,11 +218,11 @@ async fn get_paste(
 /// - `200` - A list of [`ResponsePaste`] objects.
 async fn get_pastes(
     State(app): State<App>,
-    Json(body): Json<GetPastesBody>,
+    Json(body): Json<Vec<Snowflake>>,
 ) -> Result<Response, AppError> {
     let mut response_pastes: Vec<ResponsePaste> = Vec::new();
 
-    for paste_id in body.ids {
+    for paste_id in body {
         let paste = Paste::fetch(&app.database, paste_id)
             .await?
             .ok_or_else(|| AppError::NotFound("Paste not found.".to_string()))?;

--- a/src/rest/paste.rs
+++ b/src/rest/paste.rs
@@ -399,9 +399,7 @@ async fn post_paste(
     }
 
     for (document, content) in documents {
-        app.s3
-            .create_document(document.generate_path(), content.into())
-            .await?;
+        app.s3.create_document(&document, content.into()).await?;
 
         document.update(&mut transaction).await?;
     }


### PR DESCRIPTION
---
### Bugs
 - Documents stored in MINIO were always stored as `text/plain`. This is no longer the case.
 - `.update(...)` has been split into `.update(...)` (the same) and `.insert(...)` (Only inserts, fails if the item already exists.)

---
### Cleanup
 - Reorder and move the transaction and paste_id generation in `POST /pastes` to a position after some basic validation (where it is not needed or used.)
 - Payload objects are now located in `/src/models/payload.rs` (instead of in the `/rest/*.rs` file directly), and now use type to minimise the duplicate structs.
 - `GET /pastes` now takes an array of pastes, and not a object with an item named `ids`.