### PR TITLE
Cleanup config.

### DIFF
--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -1,6 +1,6 @@
 use derive_builder::Builder;
 use dotenvy::from_filename;
-use secrecy::SecretString;
+use secrecy::{SecretBox, SecretString};
 
 #[derive(Debug, Clone, Builder)]
 pub struct Config {
@@ -32,30 +32,8 @@ pub struct Config {
     global_paste_total_document_size_limit: usize,
     /// Individual paste document size.
     global_paste_document_size_limit: usize,
-    /// Global rate limiter.
-    global_rate_limiter: u32,
-    /// Global paste rate limiter.
-    global_paste_rate_limiter: u32,
-    /// Get pastes rate limiter.
-    get_pastes_rate_limiter: u32,
-    /// Get paste rate limiter.
-    get_paste_rate_limiter: u32,
-    /// Post paste rate limiter.
-    post_paste_rate_limiter: u32,
-    /// Patch paste rate limiter.
-    patch_paste_rate_limiter: u32,
-    /// Delete paste rate limiter.
-    delete_paste_rate_limiter: u32,
-    /// Global paste rate limiter.
-    global_document_rate_limiter: u32,
-    /// Get paste rate limiter.
-    get_document_rate_limiter: u32,
-    /// Post paste rate limiter.
-    post_document_rate_limiter: u32,
-    /// Patch paste rate limiter.
-    patch_document_rate_limiter: u32,
-    /// Delete paste rate limiter.
-    delete_document_rate_limiter: u32,
+    // Rate limits.
+    rate_limits: RateLimitConfig,
 }
 
 impl Config {
@@ -108,82 +86,33 @@ impl Config {
                     .expect("DEFAULT_EXPIRY_HOURS requires an integer.")
             }))
             .global_paste_total_document_count(
-                std::env::var("GLOBAL_PASTE_TOTAL_DOCUMENT_COUNT").map_or(10, |v| {
-                    v.parse()
-                        .expect("GLOBAL_PASTE_TOTAL_DOCUMENT_COUNT requires an integer.")
-                }),
+                std::env::var("GLOBAL_PASTE_TOTAL_DOCUMENT_COUNT").map_or(
+                    Self::default().global_paste_total_document_count,
+                    |v| {
+                        v.parse()
+                            .expect("GLOBAL_PASTE_TOTAL_DOCUMENT_COUNT requires an integer.")
+                    },
+                ),
             )
             .global_paste_total_document_size_limit(
-                std::env::var("SIZE_LIMIT_GLOBAL_PASTE_TOTAL_DOCUMENT").map_or(100, |v| {
-                    v.parse()
-                        .expect("SIZE_LIMIT_GLOBAL_PASTE_TOTAL_DOCUMENT requires an integer.")
-                }),
+                std::env::var("SIZE_LIMIT_GLOBAL_PASTE_TOTAL_DOCUMENT").map_or(
+                    Self::default().global_paste_document_size_limit,
+                    |v| {
+                        v.parse()
+                            .expect("SIZE_LIMIT_GLOBAL_PASTE_TOTAL_DOCUMENT requires an integer.")
+                    },
+                ),
             )
             .global_paste_document_size_limit(
-                std::env::var("SIZE_LIMIT_GLOBAL_PASTE_DOCUMENT").map_or(15, |v| {
-                    v.parse()
-                        .expect("SIZE_LIMIT_GLOBAL_PASTE_DOCUMENT requires an integer.")
-                }),
+                std::env::var("SIZE_LIMIT_GLOBAL_PASTE_DOCUMENT").map_or(
+                    Self::default().global_paste_document_size_limit,
+                    |v| {
+                        v.parse()
+                            .expect("SIZE_LIMIT_GLOBAL_PASTE_DOCUMENT requires an integer.")
+                    },
+                ),
             )
-            .global_rate_limiter(std::env::var("RATE_LIMIT_GLOBAL").map_or(800, |v| {
-                v.parse().expect("RATE_LIMIT_GLOBAL requires an integer.")
-            }))
-            .global_paste_rate_limiter(std::env::var("RATE_LIMIT_GLOBAL_PASTE").map_or(500, |v| {
-                v.parse()
-                    .expect("RATE_LIMIT_GLOBAL_PASTE requires an integer.")
-            }))
-            .get_pastes_rate_limiter(std::env::var("RATE_LIMIT_GET_PASTES").map_or(40, |v| {
-                v.parse()
-                    .expect("RATE_LIMIT_GET_PASTES requires an integer.")
-            }))
-            .get_paste_rate_limiter(std::env::var("RATE_LIMIT_GET_PASTE").map_or(200, |v| {
-                v.parse()
-                    .expect("RATE_LIMIT_GET_PASTE requires an integer.")
-            }))
-            .post_paste_rate_limiter(std::env::var("RATE_LIMIT_POST_PASTE").map_or(100, |v| {
-                v.parse()
-                    .expect("RATE_LIMIT_POST_PASTE requires an integer.")
-            }))
-            .patch_paste_rate_limiter(std::env::var("RATE_LIMIT_PATCH_PASTE").map_or(120, |v| {
-                v.parse()
-                    .expect("RATE_LIMIT_PATCH_PASTE requires an integer.")
-            }))
-            .delete_paste_rate_limiter(std::env::var("RATE_LIMIT_DELETE_PASTE").map_or(200, |v| {
-                v.parse()
-                    .expect("RATE_LIMIT_DELETE_PASTE requires an integer.")
-            }))
-            .global_document_rate_limiter(std::env::var("RATE_LIMIT_GLOBAL_DOCUMENT").map_or(
-                500,
-                |v| {
-                    v.parse()
-                        .expect("RATE_LIMIT_GLOBAL_PASTE requires an integer.")
-                },
-            ))
-            .get_document_rate_limiter(std::env::var("RATE_LIMIT_GET_DOCUMENT").map_or(200, |v| {
-                v.parse()
-                    .expect("RATE_LIMIT_GET_PASTE requires an integer.")
-            }))
-            .post_document_rate_limiter(std::env::var("RATE_LIMIT_POST_DOCUMENT").map_or(
-                100,
-                |v| {
-                    v.parse()
-                        .expect("RATE_LIMIT_POST_PASTE requires an integer.")
-                },
-            ))
-            .patch_document_rate_limiter(std::env::var("RATE_LIMIT_PATCH_DOCUMENT").map_or(
-                120,
-                |v| {
-                    v.parse()
-                        .expect("RATE_LIMIT_PATCH_PASTE requires an integer.")
-                },
-            ))
-            .delete_document_rate_limiter(std::env::var("RATE_LIMIT_DELETE_DOCUMENT").map_or(
-                200,
-                |v| {
-                    v.parse()
-                        .expect("RATE_LIMIT_DELETE_PASTE requires an integer.")
-                },
-            ))
+            .rate_limits(RateLimitConfig::from_env(false))
             .build()
             .expect("Failed to create application configuration.");
 
@@ -255,51 +184,223 @@ impl Config {
         self.global_paste_document_size_limit
     }
 
-    pub const fn global_rate_limiter(&self) -> u32 {
-        self.global_rate_limiter
+    pub fn rate_limits(&self) -> RateLimitConfig {
+        self.rate_limits.clone()
+    }
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            host: String::default(),
+            port: Default::default(),
+            database_url: String::default(),
+            s3_url: String::default(),
+            s3_access_key: SecretBox::default(),
+            s3_secret_key: SecretBox::default(),
+            minio_root_user: String::default(),
+            minio_root_password: SecretBox::default(),
+            domain: String::default(),
+            maximum_expiry_hours: None,
+            default_expiry_hours: None,
+            global_paste_total_document_count: 10,
+            global_paste_total_document_size_limit: 100,
+            global_paste_document_size_limit: 15,
+            rate_limits: RateLimitConfig::default(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Builder)]
+#[builder(default)]
+pub struct RateLimitConfig {
+    /// Global rate limiter.
+    global: u32,
+    /// Global paste rate limiter.
+    global_paste: u32,
+    /// Get pastes rate limiter.
+    get_pastes: u32,
+    /// Get paste rate limiter.
+    get_paste: u32,
+    /// Post paste rate limiter.
+    post_paste: u32,
+    /// Patch paste rate limiter.
+    patch_paste: u32,
+    /// Delete paste rate limiter.
+    delete_paste: u32,
+    /// Global paste rate limiter.
+    global_document: u32,
+    /// Get paste rate limiter.
+    get_document: u32,
+    /// Post paste rate limiter.
+    post_document: u32,
+    /// Patch paste rate limiter.
+    patch_document: u32,
+    /// Delete paste rate limiter.
+    delete_document: u32,
+}
+
+impl RateLimitConfig {
+    pub fn builder() -> RateLimitConfigBuilder {
+        RateLimitConfigBuilder::default()
     }
 
-    pub const fn global_paste_rate_limiter(&self) -> u32 {
-        self.global_paste_rate_limiter
+    #[allow(clippy::too_many_lines)]
+    pub fn from_env(fetch_env: bool) -> Self {
+        if fetch_env {
+            from_filename(".env").ok();
+        }
+
+        let defaults = Self::default();
+
+        Self::builder()
+            .global(
+                std::env::var("RATE_LIMIT_GLOBAL").map_or(defaults.global, |v| {
+                    v.parse().expect("RATE_LIMIT_GLOBAL requires an integer.")
+                }),
+            )
+            .global_paste(std::env::var("RATE_LIMIT_GLOBAL_PASTE").map_or(
+                defaults.global_paste,
+                |v| {
+                    v.parse()
+                        .expect("RATE_LIMIT_GLOBAL_PASTE requires an integer.")
+                },
+            ))
+            .get_pastes(
+                std::env::var("RATE_LIMIT_GET_PASTES").map_or(defaults.get_pastes, |v| {
+                    v.parse()
+                        .expect("RATE_LIMIT_GET_PASTES requires an integer.")
+                }),
+            )
+            .get_paste(
+                std::env::var("RATE_LIMIT_GET_PASTE").map_or(defaults.get_paste, |v| {
+                    v.parse()
+                        .expect("RATE_LIMIT_GET_PASTE requires an integer.")
+                }),
+            )
+            .post_paste(
+                std::env::var("RATE_LIMIT_POST_PASTE").map_or(defaults.post_paste, |v| {
+                    v.parse()
+                        .expect("RATE_LIMIT_POST_PASTE requires an integer.")
+                }),
+            )
+            .patch_paste(std::env::var("RATE_LIMIT_PATCH_PASTE").map_or(
+                defaults.patch_paste,
+                |v| {
+                    v.parse()
+                        .expect("RATE_LIMIT_PATCH_PASTE requires an integer.")
+                },
+            ))
+            .delete_paste(std::env::var("RATE_LIMIT_DELETE_PASTE").map_or(
+                defaults.delete_paste,
+                |v| {
+                    v.parse()
+                        .expect("RATE_LIMIT_DELETE_PASTE requires an integer.")
+                },
+            ))
+            .global_document(std::env::var("RATE_LIMIT_GLOBAL_DOCUMENT").map_or(
+                defaults.global_document,
+                |v| {
+                    v.parse()
+                        .expect("RATE_LIMIT_GLOBAL_DOCUMENT requires an integer.")
+                },
+            ))
+            .get_document(std::env::var("RATE_LIMIT_GET_DOCUMENT").map_or(
+                defaults.get_document,
+                |v| {
+                    v.parse()
+                        .expect("RATE_LIMIT_GET_DOCUMENT requires an integer.")
+                },
+            ))
+            .post_document(std::env::var("RATE_LIMIT_POST_DOCUMENT").map_or(
+                defaults.post_document,
+                |v| {
+                    v.parse()
+                        .expect("RATE_LIMIT_POST_DOCUMENT requires an integer.")
+                },
+            ))
+            .patch_document(std::env::var("RATE_LIMIT_PATCH_DOCUMENT").map_or(
+                defaults.patch_document,
+                |v| {
+                    v.parse()
+                        .expect("RATE_LIMIT_PATCH_DOCUMENT requires an integer.")
+                },
+            ))
+            .delete_document(std::env::var("RATE_LIMIT_DELETE_DOCUMENT").map_or(
+                defaults.delete_document,
+                |v| {
+                    v.parse()
+                        .expect("RATE_LIMIT_DELETE_DOCUMENT requires an integer.")
+                },
+            ))
+            .build()
+            .expect("Failed to create application configuration.")
     }
 
-    pub const fn get_pastes_rate_limiter(&self) -> u32 {
-        self.get_pastes_rate_limiter
+    pub const fn global(&self) -> u32 {
+        self.global
     }
 
-    pub const fn get_paste_rate_limiter(&self) -> u32 {
-        self.get_paste_rate_limiter
+    pub const fn global_paste(&self) -> u32 {
+        self.global_paste
     }
 
-    pub const fn post_paste_rate_limiter(&self) -> u32 {
-        self.post_paste_rate_limiter
+    pub const fn get_pastes(&self) -> u32 {
+        self.get_pastes
     }
 
-    pub const fn patch_paste_rate_limiter(&self) -> u32 {
-        self.patch_paste_rate_limiter
+    pub const fn get_paste(&self) -> u32 {
+        self.get_paste
     }
 
-    pub const fn delete_paste_rate_limiter(&self) -> u32 {
-        self.delete_paste_rate_limiter
+    pub const fn post_paste(&self) -> u32 {
+        self.post_paste
     }
 
-    pub const fn global_document_rate_limiter(&self) -> u32 {
-        self.global_document_rate_limiter
+    pub const fn patch_paste(&self) -> u32 {
+        self.patch_paste
     }
 
-    pub const fn get_document_rate_limiter(&self) -> u32 {
-        self.get_document_rate_limiter
+    pub const fn delete_paste(&self) -> u32 {
+        self.delete_paste
     }
 
-    pub const fn post_document_rate_limiter(&self) -> u32 {
-        self.post_document_rate_limiter
+    pub const fn global_document(&self) -> u32 {
+        self.global_document
     }
 
-    pub const fn patch_document_rate_limiter(&self) -> u32 {
-        self.patch_document_rate_limiter
+    pub const fn get_document(&self) -> u32 {
+        self.get_document
     }
 
-    pub const fn delete_document_rate_limiter(&self) -> u32 {
-        self.delete_document_rate_limiter
+    pub const fn post_document(&self) -> u32 {
+        self.post_document
+    }
+
+    pub const fn patch_document(&self) -> u32 {
+        self.patch_document
+    }
+
+    pub const fn delete_document(&self) -> u32 {
+        self.delete_document
+    }
+}
+
+impl Default for RateLimitConfig {
+    fn default() -> Self {
+        Self {
+            global: 800,
+            global_paste: 500,
+            get_pastes: 40,
+            get_paste: 200,
+            post_paste: 100,
+            patch_paste: 120,
+            delete_paste: 200,
+            global_document: 500,
+            get_document: 200,
+            post_document: 100,
+            patch_document: 120,
+            delete_document: 200,
+        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,7 +86,7 @@ async fn main() {
         config: Arc::new(
             GovernorConfigBuilder::default()
                 .per_second(60)
-                .burst_size(state.config.global_rate_limiter())
+                .burst_size(state.config.rate_limits().global())
                 .period(Duration::from_secs(5))
                 .use_headers()
                 .finish()

--- a/src/rest/document.rs
+++ b/src/rest/document.rs
@@ -31,7 +31,7 @@ pub fn generate_router(config: &Config) -> Router<App> {
         config: Arc::new(
             GovernorConfigBuilder::default()
                 .per_second(60)
-                .burst_size(config.global_document_rate_limiter())
+                .burst_size(config.rate_limits().global_document())
                 .period(Duration::from_secs(5))
                 .use_headers()
                 .finish()
@@ -43,7 +43,7 @@ pub fn generate_router(config: &Config) -> Router<App> {
         config: Arc::new(
             GovernorConfigBuilder::default()
                 .per_second(60)
-                .burst_size(config.get_document_rate_limiter())
+                .burst_size(config.rate_limits().get_document())
                 .period(Duration::from_secs(5))
                 .use_headers()
                 .finish()
@@ -55,7 +55,7 @@ pub fn generate_router(config: &Config) -> Router<App> {
         config: Arc::new(
             GovernorConfigBuilder::default()
                 .per_second(60)
-                .burst_size(config.post_document_rate_limiter())
+                .burst_size(config.rate_limits().post_document())
                 .period(Duration::from_secs(5))
                 .use_headers()
                 .finish()
@@ -67,7 +67,7 @@ pub fn generate_router(config: &Config) -> Router<App> {
         config: Arc::new(
             GovernorConfigBuilder::default()
                 .per_second(60)
-                .burst_size(config.patch_document_rate_limiter())
+                .burst_size(config.rate_limits().patch_document())
                 .period(Duration::from_secs(5))
                 .use_headers()
                 .finish()
@@ -79,7 +79,7 @@ pub fn generate_router(config: &Config) -> Router<App> {
         config: Arc::new(
             GovernorConfigBuilder::default()
                 .per_second(60)
-                .burst_size(config.delete_document_rate_limiter())
+                .burst_size(config.rate_limits().delete_document())
                 .period(Duration::from_secs(5))
                 .use_headers()
                 .finish()

--- a/src/rest/paste.rs
+++ b/src/rest/paste.rs
@@ -30,7 +30,7 @@ pub fn generate_router(config: &Config) -> Router<App> {
         config: Arc::new(
             GovernorConfigBuilder::default()
                 .per_second(60)
-                .burst_size(config.global_paste_rate_limiter())
+                .burst_size(config.rate_limits().global_paste())
                 .period(Duration::from_secs(5))
                 .use_headers()
                 .finish()
@@ -42,7 +42,7 @@ pub fn generate_router(config: &Config) -> Router<App> {
         config: Arc::new(
             GovernorConfigBuilder::default()
                 .per_second(60)
-                .burst_size(config.get_pastes_rate_limiter())
+                .burst_size(config.rate_limits().get_pastes())
                 .period(Duration::from_secs(5))
                 .use_headers()
                 .finish()
@@ -54,7 +54,7 @@ pub fn generate_router(config: &Config) -> Router<App> {
         config: Arc::new(
             GovernorConfigBuilder::default()
                 .per_second(60)
-                .burst_size(config.get_paste_rate_limiter())
+                .burst_size(config.rate_limits().get_paste())
                 .period(Duration::from_secs(5))
                 .use_headers()
                 .finish()
@@ -66,7 +66,7 @@ pub fn generate_router(config: &Config) -> Router<App> {
         config: Arc::new(
             GovernorConfigBuilder::default()
                 .per_second(60)
-                .burst_size(config.post_paste_rate_limiter())
+                .burst_size(config.rate_limits().post_paste())
                 .period(Duration::from_secs(5))
                 .use_headers()
                 .finish()
@@ -78,7 +78,7 @@ pub fn generate_router(config: &Config) -> Router<App> {
         config: Arc::new(
             GovernorConfigBuilder::default()
                 .per_second(60)
-                .burst_size(config.patch_paste_rate_limiter())
+                .burst_size(config.rate_limits().patch_paste())
                 .period(Duration::from_secs(5))
                 .use_headers()
                 .finish()
@@ -90,7 +90,7 @@ pub fn generate_router(config: &Config) -> Router<App> {
         config: Arc::new(
             GovernorConfigBuilder::default()
                 .per_second(60)
-                .burst_size(config.delete_paste_rate_limiter())
+                .burst_size(config.rate_limits().delete_paste())
                 .period(Duration::from_secs(5))
                 .use_headers()
                 .finish()
@@ -540,7 +540,10 @@ fn validate_expiry(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{app::config::Config, models::error::AppError};
+    use crate::{
+        app::config::{Config, RateLimitConfigBuilder},
+        models::error::AppError,
+    };
     use time::Duration;
 
     fn make_config(
@@ -562,18 +565,11 @@ mod tests {
             .global_paste_total_document_count(0)
             .global_paste_total_document_size_limit(0)
             .global_paste_document_size_limit(0)
-            .global_rate_limiter(0)
-            .global_paste_rate_limiter(0)
-            .get_pastes_rate_limiter(0)
-            .get_paste_rate_limiter(0)
-            .post_paste_rate_limiter(0)
-            .patch_paste_rate_limiter(0)
-            .delete_paste_rate_limiter(0)
-            .global_document_rate_limiter(0)
-            .get_document_rate_limiter(0)
-            .post_document_rate_limiter(0)
-            .patch_document_rate_limiter(0)
-            .delete_document_rate_limiter(0)
+            .rate_limits(
+                RateLimitConfigBuilder::default()
+                    .build()
+                    .expect("Failed to build rate limits"),
+            )
             .build()
             .expect("Failed to build config.")
     }


### PR DESCRIPTION
Config has been split, so that rate limiting items are now in there own section.

Defaults for values that need a default, have now been clearly set.