### PR TITLE
Add support for smaller file sizes.

### DIFF
--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -29,9 +29,9 @@ pub struct Config {
     /// The maximum allowed documents in a paste.
     global_paste_total_document_count: usize,
     /// Maximum paste body size.
-    global_paste_total_document_size_limit: usize,
+    global_paste_total_document_size_limit: f64,
     /// Individual paste document size.
-    global_paste_document_size_limit: usize,
+    global_paste_document_size_limit: f64,
     // Rate limits.
     rate_limits: RateLimitConfig,
 }
@@ -176,11 +176,11 @@ impl Config {
         self.global_paste_total_document_count
     }
 
-    pub const fn global_paste_total_document_size_limit(&self) -> usize {
+    pub const fn global_paste_total_document_size_limit(&self) -> f64 {
         self.global_paste_total_document_size_limit
     }
 
-    pub const fn global_paste_document_size_limit(&self) -> usize {
+    pub const fn global_paste_document_size_limit(&self) -> f64 {
         self.global_paste_document_size_limit
     }
 
@@ -204,8 +204,8 @@ impl Default for Config {
             maximum_expiry_hours: None,
             default_expiry_hours: None,
             global_paste_total_document_count: 10,
-            global_paste_total_document_size_limit: 100,
-            global_paste_document_size_limit: 15,
+            global_paste_total_document_size_limit: 100.0,
+            global_paste_document_size_limit: 15.0,
             rate_limits: RateLimitConfig::default(),
         }
     }

--- a/src/models/payload.rs
+++ b/src/models/payload.rs
@@ -47,9 +47,9 @@ pub struct ResponseConfig {
     /// The maximum document count.
     pub maximum_document_count: usize,
     /// The maximum individual document size in mb.
-    pub maximum_document_size: usize,
+    pub maximum_document_size: f64,
     /// The maximum total size of all documents in mb. (includes payload)
-    pub maximum_total_document_size: usize,
+    pub maximum_total_document_size: f64,
 }
 
 impl ResponseConfig {
@@ -60,8 +60,8 @@ impl ResponseConfig {
         default_expiry: Option<usize>,
         maximum_expiry: Option<usize>,
         maximum_document_count: usize,
-        maximum_document_size: usize,
-        maximum_total_document_size: usize,
+        maximum_document_size: f64,
+        maximum_total_document_size: f64,
     ) -> Self {
         Self {
             default_expiry,

--- a/src/rest/config.rs
+++ b/src/rest/config.rs
@@ -43,7 +43,7 @@ pub fn generate_router(config: &Config) -> Router<App> {
         .route("/config", get(get_config).layer(get_config_limiter))
         .layer(global_limiter)
         .layer(DefaultBodyLimit::max(
-            config.global_paste_total_document_size_limit() * 1024 * 1024,
+            (config.global_paste_total_document_size_limit() * 1024.0 * 1024.0) as usize,
         ))
 }
 

--- a/src/rest/document.rs
+++ b/src/rest/document.rs
@@ -106,7 +106,7 @@ pub fn generate_router(config: &Config) -> Router<App> {
         )
         .layer(global_limiter)
         .layer(DefaultBodyLimit::max(
-            config.global_paste_total_document_size_limit() * 1024 * 1024,
+            (config.global_paste_total_document_size_limit() * 1024.0 * 1024.0) as usize,
         ))
 }
 
@@ -207,8 +207,8 @@ async fn post_document(
 
     let total_document_size = Document::fetch_total_document_size(&app.database, paste_id).await?;
 
-    if (app.config.global_paste_total_document_size_limit() * 1024 * 1024)
-        < (total_document_size + body.len())
+    if (app.config.global_paste_total_document_size_limit() * 1024.0 * 1024.0)
+        < (total_document_size + body.len()) as f64
     {
         return Err(AppError::BadRequest(
             "The new content exceeds the total document limit.".to_string(),
@@ -309,8 +309,8 @@ async fn patch_document(
 
     let total_document_size = Document::fetch_total_document_size(&app.database, paste_id).await?;
 
-    if (app.config.global_paste_total_document_size_limit() * 1024 * 1024)
-        >= (total_document_size + body.len())
+    if (app.config.global_paste_total_document_size_limit() * 1024.0 * 1024.0)
+        >= (total_document_size + body.len()) as f64
     {
         return Err(AppError::BadRequest(
             "The new content exceeds the total document limit.".to_string(),

--- a/src/rest/paste.rs
+++ b/src/rest/paste.rs
@@ -116,7 +116,7 @@ pub fn generate_router(config: &Config) -> Router<App> {
         )
         .layer(global_limiter)
         .layer(DefaultBodyLimit::max(
-            config.global_paste_total_document_size_limit() * 1024 * 1024,
+            (config.global_paste_total_document_size_limit() * 1024.0 * 1024.0) as usize,
         ))
 }
 
@@ -304,7 +304,7 @@ async fn post_paste(
             .to_string();
         let data = field.bytes().await?;
 
-        if data.len() > (app.config.global_paste_document_size_limit() * 1024 * 1024) {
+        if data.len() as f64 > (app.config.global_paste_document_size_limit() * 1024.0 * 1024.0) {
             return Err(AppError::NotFound("Document too large.".to_string()));
         }
 
@@ -583,8 +583,8 @@ mod tests {
             .maximum_expiry_hours(maximum_expiry_hours)
             .default_expiry_hours(default_expiry_hours)
             .global_paste_total_document_count(0)
-            .global_paste_total_document_size_limit(0)
-            .global_paste_document_size_limit(0)
+            .global_paste_total_document_size_limit(0.0)
+            .global_paste_document_size_limit(0.0)
             .rate_limits(
                 RateLimitConfigBuilder::default()
                     .build()


### PR DESCRIPTION
This support allows for file sizes smaller than 1mb, like 0.5mb (500kb) for example.