### PR TITLE
Add speedups.

### DIFF
--- a/src/app/application.rs
+++ b/src/app/application.rs
@@ -11,9 +11,9 @@ pub type App = Arc<ApplicationState>;
 pub type S3Client = Client;
 
 pub struct ApplicationState {
-    pub config: Config,
-    pub database: Database,
-    pub s3: S3Service,
+    config: Config,
+    database: Database,
+    s3: S3Service,
 }
 
 impl ApplicationState {
@@ -64,10 +64,23 @@ impl ApplicationState {
         }))
     }
 
+    #[inline]
+    pub const fn config(&self) -> &Config {
+        &self.config
+    }
+
+    #[inline]
+    pub const fn database(&self) -> &Database {
+        &self.database
+    }
+
+    #[inline]
+    pub const fn s3(&self) -> &S3Service {
+        &self.s3
+    }
+
     async fn init(&mut self) -> Result<(), AppError> {
-        self.database
-            .connect(self.config.database_url().as_str())
-            .await?;
+        self.database.connect(self.config.database_url()).await?;
 
         self.s3.create_buckets().await?;
 

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -77,48 +77,48 @@ impl Config {
             .expect("Failed to create application configuration.")
     }
 
-    pub fn host(&self) -> String {
-        self.host.clone()
+    pub fn host(&self) -> &str {
+        &self.host
     }
 
     pub const fn port(&self) -> u16 {
         self.port
     }
 
-    pub fn database_url(&self) -> String {
-        self.database_url.clone()
+    pub fn database_url(&self) -> &str {
+        &self.database_url
     }
 
-    pub fn s3_url(&self) -> String {
-        self.s3_url.clone()
+    pub fn s3_url(&self) -> &str {
+        &self.s3_url
     }
 
-    pub fn s3_access_key(&self) -> SecretString {
-        self.s3_access_key.clone()
+    pub const fn s3_access_key(&self) -> &SecretString {
+        &self.s3_access_key
     }
 
-    pub fn s3_secret_key(&self) -> SecretString {
-        self.s3_secret_key.clone()
+    pub const fn s3_secret_key(&self) -> &SecretString {
+        &self.s3_secret_key
     }
 
-    pub fn minio_root_user(&self) -> String {
-        self.minio_root_user.clone()
+    pub fn minio_root_user(&self) -> &str {
+        &self.minio_root_user
     }
 
-    pub fn minio_root_password(&self) -> SecretString {
-        self.minio_root_password.clone()
+    pub const fn minio_root_password(&self) -> &SecretString {
+        &self.minio_root_password
     }
 
-    pub fn domain(&self) -> String {
-        self.domain.clone()
+    pub fn domain(&self) -> &str {
+        &self.domain
     }
 
-    pub fn size_limits(&self) -> SizeLimitConfig {
-        self.size_limits.clone()
+    pub const fn size_limits(&self) -> &SizeLimitConfig {
+        &self.size_limits
     }
 
-    pub fn rate_limits(&self) -> RateLimitConfig {
-        self.rate_limits.clone()
+    pub const fn rate_limits(&self) -> &RateLimitConfig {
+        &self.rate_limits
     }
 }
 

--- a/src/app/s3.rs
+++ b/src/app/s3.rs
@@ -167,7 +167,7 @@ impl S3Service {
         self.client
             .put_object()
             .bucket(self.document_bucket_name())
-            .content_type(document.document_type.clone())
+            .content_type(document.doc_type())
             .key(document.generate_path())
             .body(ByteStream::from(content.into()))
             .send()

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,10 +65,13 @@ async fn main() {
             Err(err) => panic!("Failed to build state: {err}"),
         };
 
+    let expiry_state = state.clone();
+
+    let config = state.config().clone();
+
     let cors = CorsLayer::new()
         .allow_origin(
-            state
-                .config
+            config
                 .domain()
                 .parse::<HeaderValue>()
                 .expect("Failed to parse CORS domain."),
@@ -87,7 +90,7 @@ async fn main() {
         config: Arc::new(
             GovernorConfigBuilder::default()
                 .per_second(60)
-                .burst_size(state.config.rate_limits().global())
+                .burst_size(config.rate_limits().global())
                 .period(Duration::from_secs(5))
                 .use_headers()
                 .finish()
@@ -96,18 +99,18 @@ async fn main() {
     };
 
     let app = Router::new()
-        .nest("/v1", rest::paste::generate_router(&state.config))
-        .nest("/v1", rest::document::generate_router(&state.config))
-        .nest("/v1", rest::config::generate_router(&state.config))
+        .nest("/v1", rest::paste::generate_router(&config))
+        .nest("/v1", rest::document::generate_router(&config))
+        .nest("/v1", rest::config::generate_router(&config))
         .layer(TraceLayer::new_for_http())
         .layer(TimeoutLayer::new(Duration::from_secs(10)))
         .layer(cors)
         .layer(limiter)
         .fallback(fallback)
-        .with_state(state.clone());
+        .with_state(state);
 
-    let host = state.config.host();
-    let port = state.config.port();
+    let host = config.host();
+    let port = config.port();
 
     let version = env!("CARGO_PKG_VERSION");
 
@@ -120,7 +123,7 @@ async fn main() {
 
     let (expire_sender, expire_receiver) = mpsc::channel::<ExpiryTaskMessage>(10);
 
-    let expiry_task = tokio::task::spawn(expiry_tasks(state, expire_receiver));
+    let expiry_task = tokio::task::spawn(expiry_tasks(expiry_state, expire_receiver));
 
     let listener = tokio::net::TcpListener::bind(format!("{host}:{port}"))
         .await

--- a/src/models/authentication.rs
+++ b/src/models/authentication.rs
@@ -32,13 +32,15 @@ impl Token {
     }
 
     /// The owning paste ID.
+    #[inline]
     pub const fn paste_id(&self) -> Snowflake {
         self.paste_id
     }
 
     /// The authentication token.
-    pub fn token(&self) -> SecretString {
-        self.token.clone()
+    #[inline]
+    pub const fn token(&self) -> &SecretString {
+        &self.token
     }
 
     /// Fetch.
@@ -58,7 +60,7 @@ impl Token {
     ///
     /// - [`Option::Some`] - The [`Token`] object.
     /// - [`Option::None`] - No token was found.
-    pub async fn fetch<'e, 'c: 'e, E>(executor: E, token: String) -> Result<Option<Self>, AppError>
+    pub async fn fetch<'e, 'c: 'e, E>(executor: E, token: &str) -> Result<Option<Self>, AppError>
     where
         E: 'e + PgExecutor<'c>,
     {
@@ -110,7 +112,7 @@ impl Token {
     /// ## Errors
     ///
     /// - [`AppError`] - The database had an error.
-    pub async fn delete<'e, 'c: 'e, E>(executor: E, token: String) -> Result<(), AppError>
+    pub async fn delete<'e, 'c: 'e, E>(executor: E, token: &str) -> Result<(), AppError>
     where
         E: 'e + PgExecutor<'c>,
     {
@@ -132,7 +134,7 @@ impl FromRequestParts<App> for Token {
             .await
             .map_err(|_| AuthError::MissingCredentials)?;
 
-        let bot = Self::fetch(state.database.pool(), bearer.token().to_string())
+        let bot = Self::fetch(state.database().pool(), bearer.token())
             .await?
             .ok_or(AuthError::InvalidToken)?;
 

--- a/src/models/document.rs
+++ b/src/models/document.rs
@@ -1,5 +1,5 @@
 use regex::Regex;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use sqlx::{PgExecutor, PgTransaction};
 
 use crate::app::config::Config;
@@ -32,7 +32,7 @@ pub const UNSUPPORTED_MIMES: &[&str] =
 
 pub const DEFAULT_MIME: &str = "text/plain";
 
-#[derive(Deserialize, Serialize, Clone, Debug)]
+#[derive(Serialize, Clone, Debug)]
 pub struct Document {
     /// The ID of the document.
     id: Snowflake,

--- a/src/models/document.rs
+++ b/src/models/document.rs
@@ -35,36 +35,66 @@ pub const DEFAULT_MIME: &str = "text/plain";
 #[derive(Deserialize, Serialize, Clone, Debug)]
 pub struct Document {
     /// The ID of the document.
-    pub id: Snowflake,
+    id: Snowflake,
     /// The paste that owns the document.
-    pub paste_id: Snowflake,
+    paste_id: Snowflake,
     /// The type of document.
     #[serde(rename = "type")]
-    pub document_type: String,
+    doc_type: String,
     /// The name of the document.
-    pub name: String,
+    name: String,
     /// The size of the document.
-    pub size: usize,
+    size: usize,
 }
 
 impl Document {
     /// New.
     ///
     /// Create a new [`Document`] object.
-    pub const fn new(
+    pub fn new(
         id: Snowflake,
         paste_id: Snowflake,
-        document_type: String,
-        name: String,
+        doc_type: &str,
+        name: &str,
         size: usize,
     ) -> Self {
         Self {
             id,
             paste_id,
-            document_type,
-            name,
+            doc_type: doc_type.to_string(),
+            name: name.to_string(),
             size,
         }
+    }
+
+    /// The documents ID.
+    #[inline]
+    pub const fn id(&self) -> &Snowflake {
+        &self.id
+    }
+
+    /// The paste ID this document belongs too.
+    #[inline]
+    pub const fn paste_id(&self) -> &Snowflake {
+        &self.paste_id
+    }
+
+    /// The documents type.
+    #[inline]
+    pub fn doc_type(&self) -> &str {
+        &self.doc_type
+    }
+
+    /// The documents name.
+    #[inline]
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// The documents size.
+    #[inline]
+    pub const fn size(&self) -> usize {
+        self.size
     }
 
     /// Generate URL.
@@ -78,6 +108,7 @@ impl Document {
     /// ## Returns
     ///
     /// The URL generated.
+    #[inline]
     pub fn generate_url(&self, base_url: &str) -> String {
         format!("{}/documents/{}", base_url, self.generate_path())
     }
@@ -89,6 +120,7 @@ impl Document {
     /// ## Returns
     ///
     /// The path generated.
+    #[inline]
     pub fn generate_path(&self) -> String {
         format!("{}/{}/{}", self.paste_id, self.id, self.name)
     }
@@ -96,21 +128,24 @@ impl Document {
     /// Set Document Type.
     ///
     /// Set the document type.
-    pub fn set_document_type(&mut self, document_type: String) {
-        self.document_type = document_type;
+    #[inline]
+    pub fn set_doc_type(&mut self, document_type: &str) {
+        self.doc_type = document_type.to_string();
     }
 
     /// Set Name.
     ///
     /// Set the document name.
-    pub fn set_name(&mut self, name: String) {
-        self.name = name;
+    #[inline]
+    pub fn set_name(&mut self, name: &str) {
+        self.name = name.to_string();
     }
 
     /// Set Size.
     ///
     /// Set the document size.
-    pub fn set_size(&mut self, size: usize) {
+    #[inline]
+    pub const fn set_size(&mut self, size: usize) {
         self.size = size;
     }
 
@@ -131,11 +166,11 @@ impl Document {
     ///
     /// - [`Option::Some`] - The [`Document`] object.
     /// - [`Option::None`] - No document was found.
-    pub async fn fetch<'e, 'c: 'e, E>(executor: E, id: Snowflake) -> Result<Option<Self>, AppError>
+    pub async fn fetch<'e, 'c: 'e, E>(executor: E, id: &Snowflake) -> Result<Option<Self>, AppError>
     where
         E: 'e + PgExecutor<'c>,
     {
-        let paste_id: i64 = id.into();
+        let paste_id: i64 = (*id).into();
         let query = sqlx::query!(
             "SELECT id, paste_id, type, name, size FROM documents WHERE id = $1",
             paste_id
@@ -147,8 +182,8 @@ impl Document {
             return Ok(Some(Self::new(
                 q.id.into(),
                 q.paste_id.into(),
-                q.r#type,
-                q.name,
+                &q.r#type,
+                &q.name,
                 q.size as usize,
             )));
         }
@@ -176,14 +211,14 @@ impl Document {
     /// - [`Option::None`] - No document was found.
     pub async fn fetch_with_paste<'e, 'c: 'e, E>(
         executor: E,
-        paste_id: Snowflake,
-        id: Snowflake,
+        paste_id: &Snowflake,
+        id: &Snowflake,
     ) -> Result<Option<Self>, AppError>
     where
         E: 'e + PgExecutor<'c>,
     {
-        let paste_id: i64 = paste_id.into();
-        let id: i64 = id.into();
+        let paste_id: i64 = (*paste_id).into();
+        let id: i64 = (*id).into();
         let query = sqlx::query!(
             "SELECT id, paste_id, type, name, size FROM documents WHERE paste_id = $1 AND id = $2",
             paste_id,
@@ -196,8 +231,8 @@ impl Document {
             return Ok(Some(Self::new(
                 q.id.into(),
                 q.paste_id.into(),
-                q.r#type,
-                q.name,
+                &q.r#type,
+                &q.name,
                 q.size as usize,
             )));
         }
@@ -221,11 +256,14 @@ impl Document {
     /// ## Returns
     ///
     /// A [`Vec`] of [`Document`]'s.
-    pub async fn fetch_all<'e, 'c: 'e, E>(executor: E, id: Snowflake) -> Result<Vec<Self>, AppError>
+    pub async fn fetch_all<'e, 'c: 'e, E>(
+        executor: E,
+        id: &Snowflake,
+    ) -> Result<Vec<Self>, AppError>
     where
         E: 'e + PgExecutor<'c>,
     {
-        let paste_id: i64 = id.into();
+        let paste_id: i64 = (*id).into();
         let query = sqlx::query!(
             "SELECT id, paste_id, type, name, size FROM documents WHERE paste_id = $1",
             paste_id
@@ -238,8 +276,8 @@ impl Document {
             documents.push(Self::new(
                 record.id.into(),
                 record.paste_id.into(),
-                record.r#type,
-                record.name,
+                &record.r#type,
+                &record.name,
                 record.size as usize,
             ));
         }
@@ -264,12 +302,12 @@ impl Document {
     /// The size of the total documents.
     pub async fn fetch_total_document_size<'e, 'c: 'e, E>(
         executor: E,
-        id: Snowflake,
+        id: &Snowflake,
     ) -> Result<usize, AppError>
     where
         E: 'e + PgExecutor<'c>,
     {
-        let id: i64 = id.into();
+        let id: i64 = (*id).into();
         let size = sqlx::query_scalar!(
             "SELECT SUM(size)::BIGINT FROM documents WHERE paste_id = $1",
             id
@@ -299,12 +337,12 @@ impl Document {
     /// The total count of documents.
     pub async fn fetch_total_document_count<'e, 'c: 'e, E>(
         executor: E,
-        id: Snowflake,
+        id: &Snowflake,
     ) -> Result<usize, AppError>
     where
         E: 'e + PgExecutor<'c>,
     {
-        let id: i64 = id.into();
+        let id: i64 = (*id).into();
         let size = sqlx::query_scalar!("SELECT COUNT(*) FROM documents WHERE paste_id = $1", id)
             .fetch_one(executor)
             .await?
@@ -335,7 +373,7 @@ impl Document {
             "INSERT INTO documents(id, paste_id, type, name, size) VALUES ($1, $2, $3, $4, $5)",
             document_id,
             paste_id,
-            self.document_type,
+            self.doc_type,
             self.name,
             self.size as i64
         )
@@ -367,7 +405,7 @@ impl Document {
             "INSERT INTO documents(id, paste_id, type, name, size) VALUES ($1, $2, $3, $4, $5) ON CONFLICT (id) DO UPDATE SET type = $3, name = $4, size = $5",
             document_id,
             paste_id,
-            self.document_type,
+            self.doc_type,
             self.name,
             self.size as i64
         ).execute(executor).await?;
@@ -387,11 +425,11 @@ impl Document {
     /// ## Errors
     ///
     /// - [`AppError`] - The database had an error.
-    pub async fn delete<'e, 'c: 'e, E>(executor: E, id: Snowflake) -> Result<bool, AppError>
+    pub async fn delete<'e, 'c: 'e, E>(executor: E, id: &Snowflake) -> Result<bool, AppError>
     where
         E: 'e + PgExecutor<'c>,
     {
-        let paste_id: i64 = id.into();
+        let paste_id: i64 = (*id).into();
         let result = sqlx::query!("DELETE FROM documents WHERE id = $1", paste_id,)
             .execute(executor)
             .await?;
@@ -506,7 +544,7 @@ pub fn document_limits(config: &Config, document: &Document) -> Result<(), AppEr
 pub async fn total_document_limits(
     transaction: &mut PgTransaction<'_>,
     config: &Config,
-    paste_id: Snowflake,
+    paste_id: &Snowflake,
 ) -> Result<(), AppError> {
     let size_limits = config.size_limits();
 

--- a/src/models/error.rs
+++ b/src/models/error.rs
@@ -74,7 +74,7 @@ where
     }
 }
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Serialize, Debug)]
 pub struct Error {
     reason: String,
     trace: Option<String>,

--- a/src/models/paste.rs
+++ b/src/models/paste.rs
@@ -18,17 +18,17 @@ use super::{
 #[derive(Debug, Clone)]
 pub struct Paste {
     /// The ID of the paste.
-    pub id: Snowflake,
+    id: Snowflake,
     /// When the paste was created.
-    pub creation: OffsetDateTime,
+    creation: OffsetDateTime,
     /// When the paste was last modified.
-    pub edited: Option<OffsetDateTime>,
+    edited: Option<OffsetDateTime>,
     /// The time at which the paste will expire.
-    pub expiry: Option<OffsetDateTime>,
+    expiry: Option<OffsetDateTime>,
     /// The amount of views a paste has.
-    pub views: usize,
+    views: usize,
     /// The maximum allowed views for a paste.
-    pub max_views: Option<usize>,
+    max_views: Option<usize>,
 }
 
 impl Paste {
@@ -53,9 +53,46 @@ impl Paste {
         }
     }
 
+    /// The pastes ID.
+    #[inline]
+    pub const fn id(&self) -> &Snowflake {
+        &self.id
+    }
+
+    /// The pastes creation time.
+    #[inline]
+    pub const fn creation(&self) -> &OffsetDateTime {
+        &self.creation
+    }
+
+    /// The pastes last edited time.
+    #[inline]
+    pub const fn edited(&self) -> Option<&OffsetDateTime> {
+        self.edited.as_ref()
+    }
+
+    /// The pastes expiry time.
+    #[inline]
+    pub const fn expiry(&self) -> Option<&OffsetDateTime> {
+        self.expiry.as_ref()
+    }
+
+    /// The pastes total view count.
+    #[inline]
+    pub const fn views(&self) -> usize {
+        self.views
+    }
+
+    /// The pastes maximum allowed views.
+    #[inline]
+    pub const fn max_views(&self) -> Option<usize> {
+        self.max_views
+    }
+
     /// Set Edited.
     ///
     /// Update the edited timestamp to the current time.
+    #[inline]
     pub fn set_edited(&mut self) {
         self.edited = Some(OffsetDateTime::now_utc());
     }
@@ -63,6 +100,7 @@ impl Paste {
     /// Set Expiry.
     ///
     /// Set or remove the expiry on the paste.
+    #[inline]
     pub const fn set_expiry(&mut self, expiry: Option<OffsetDateTime>) {
         self.expiry = expiry;
     }
@@ -70,6 +108,7 @@ impl Paste {
     /// Set Max Views.
     ///
     /// Set or remove the maximum amount of views for a paste.
+    #[inline]
     pub const fn set_max_views(&mut self, max_views: Option<usize>) {
         self.max_views = max_views;
     }
@@ -77,6 +116,7 @@ impl Paste {
     /// Set views.
     ///
     /// Allows for setting the view count of a paste, or updating it.
+    #[inline]
     pub const fn set_views(&mut self, views: usize) {
         self.views = views;
     }
@@ -98,11 +138,11 @@ impl Paste {
     ///
     /// - [`Option::Some`] - The [`Paste`] object.
     /// - [`Option::None`] - No paste was found.
-    pub async fn fetch<'e, 'c: 'e, E>(executor: E, id: Snowflake) -> Result<Option<Self>, AppError>
+    pub async fn fetch<'e, 'c: 'e, E>(executor: E, id: &Snowflake) -> Result<Option<Self>, AppError>
     where
         E: 'e + PgExecutor<'c>,
     {
-        let paste_id: i64 = id.into();
+        let paste_id: i64 = (*id).into();
         let query = sqlx::query!(
             "SELECT id, creation, edited, expiry, views, max_views FROM pastes WHERE id = $1",
             paste_id
@@ -143,8 +183,8 @@ impl Paste {
     /// A [`Vec`] of [`Paste`]'s.
     pub async fn fetch_between<'e, 'c: 'e, E>(
         executor: E,
-        start: OffsetDateTime,
-        end: OffsetDateTime,
+        start: &OffsetDateTime,
+        end: &OffsetDateTime,
     ) -> Result<Vec<Self>, AppError>
     where
         E: 'e + PgExecutor<'c>,
@@ -248,11 +288,11 @@ impl Paste {
     /// ## Errors
     ///
     /// - [`AppError`] - The database had an error.
-    pub async fn add_view<'e, 'c: 'e, E>(executor: E, id: Snowflake) -> Result<usize, AppError>
+    pub async fn add_view<'e, 'c: 'e, E>(executor: E, id: &Snowflake) -> Result<usize, AppError>
     where
         E: 'e + PgExecutor<'c>,
     {
-        let id: i64 = id.into();
+        let id: i64 = (*id).into();
 
         let views = sqlx::query_scalar!(
             "UPDATE pastes SET views = views + 1 WHERE id = $1 RETURNING views",
@@ -276,11 +316,11 @@ impl Paste {
     /// ## Errors
     ///
     /// - [`AppError`] - The database had an error.
-    pub async fn delete<'e, 'c: 'e, E>(executor: E, id: Snowflake) -> Result<bool, AppError>
+    pub async fn delete<'e, 'c: 'e, E>(executor: E, id: &Snowflake) -> Result<bool, AppError>
     where
         E: 'e + PgExecutor<'c>,
     {
-        let paste_id: i64 = id.into();
+        let paste_id: i64 = (*id).into();
         let result = sqlx::query!("DELETE FROM pastes WHERE id = $1", paste_id,)
             .execute(executor)
             .await?;
@@ -309,7 +349,7 @@ impl Paste {
 /// The paste that was checked and found.
 pub async fn validate_paste(
     db: &Database,
-    paste_id: Snowflake,
+    paste_id: &Snowflake,
     token: Option<Token>,
 ) -> Result<Paste, AppError> {
     let Some(paste) = Paste::fetch(db.pool(), paste_id).await? else {
@@ -362,7 +402,7 @@ pub enum ExpiryTaskMessage {
 pub async fn expiry_tasks(app: App, mut rx: Receiver<ExpiryTaskMessage>) {
     const MINUTES: u64 = 50;
 
-    let pastes = match collect_nearby_expired_tasks(&app.database).await {
+    let pastes = match collect_nearby_expired_tasks(app.database()).await {
         Ok(v) => v,
         Err(e) => {
             tracing::error!("Failed to collect all pastes to expire. Reason: {e}");
@@ -371,7 +411,7 @@ pub async fn expiry_tasks(app: App, mut rx: Receiver<ExpiryTaskMessage>) {
     };
 
     for paste in pastes {
-        let documents = match Document::fetch_all(app.database.pool(), paste.id).await {
+        let documents = match Document::fetch_all(app.database().pool(), &paste.id).await {
             Ok(documents) => documents,
             Err(e) => {
                 tracing::warn!(
@@ -384,20 +424,20 @@ pub async fn expiry_tasks(app: App, mut rx: Receiver<ExpiryTaskMessage>) {
         };
 
         for document in documents {
-            match app.s3.delete_document(document.generate_path()).await {
+            match app.s3().delete_document(document.generate_path()).await {
                 Ok(()) => tracing::trace!(
                     "Successfully deleted paste document (minio): {}",
-                    document.id
+                    document.id()
                 ),
                 Err(e) => tracing::trace!(
                     "Failed to delete paste document: {} (minio). Reason: {}",
-                    document.id,
+                    document.id(),
                     e
                 ),
             }
         }
 
-        match Paste::delete(app.database.pool(), paste.id).await {
+        match Paste::delete(app.database().pool(), &paste.id).await {
             Ok(_) => tracing::trace!("Successfully deleted paste: {}", paste.id),
             Err(e) => tracing::warn!("Failure to delete paste: {}. Reason: {}", paste.id, e),
         }
@@ -422,7 +462,7 @@ pub async fn expiry_tasks(app: App, mut rx: Receiver<ExpiryTaskMessage>) {
                 }
             }
             () = &mut sleep => {
-                let pastes = match collect_nearby_expired_tasks(&app.database).await {
+                let pastes = match collect_nearby_expired_tasks(app.database()).await {
                     Ok(v) => v,
                     Err(e) => {
                         tracing::error!("Failed to collect all pastes to expire. Reason: {e}");
@@ -432,7 +472,7 @@ pub async fn expiry_tasks(app: App, mut rx: Receiver<ExpiryTaskMessage>) {
 
                 // FIXME: Please tell me there is a cleaner way of doing this.
                 for paste in pastes {
-                    let documents = match Document::fetch_all(app.database.pool(), paste.id).await {
+                    let documents = match Document::fetch_all(app.database().pool(), &paste.id).await {
                         Ok(documents) => documents,
                         Err(e) => {
                             tracing::warn!("Failed to fetch documents for paste {}. Reason: {}", paste.id, e);
@@ -441,13 +481,13 @@ pub async fn expiry_tasks(app: App, mut rx: Receiver<ExpiryTaskMessage>) {
                     };
 
                     for document in documents {
-                        match app.s3.delete_document(document.generate_path()).await {
-                            Ok(()) => tracing::trace!("Successfully deleted paste document (minio): {}", document.id),
-                            Err(e) => tracing::trace!("Failed to delete paste document: {} (minio). Reason: {}", document.id, e)
+                        match app.s3().delete_document(document.generate_path()).await {
+                            Ok(()) => tracing::trace!("Successfully deleted paste document (minio): {}", document.id()),
+                            Err(e) => tracing::trace!("Failed to delete paste document: {} (minio). Reason: {}", document.id(), e)
                         }
                     }
 
-                    match Paste::delete(app.database.pool(), paste.id).await {
+                    match Paste::delete(app.database().pool(), &paste.id).await {
                         Ok(_) => tracing::trace!("Successfully deleted paste: {}", paste.id),
                         Err(e) => tracing::warn!("Failure to delete paste: {}. Reason: {}", paste.id, e)
                     }
@@ -477,5 +517,5 @@ async fn collect_nearby_expired_tasks(db: &Database) -> Result<Vec<Paste>, AppEr
         .expect("Failed to make a timestamp with the time of 0.");
     let end = OffsetDateTime::now_utc();
 
-    Paste::fetch_between(db.pool(), start, end).await
+    Paste::fetch_between(db.pool(), &start, &end).await
 }

--- a/src/models/payload.rs
+++ b/src/models/payload.rs
@@ -48,7 +48,7 @@ impl ResponseConfig {
     /// From config.
     ///
     /// Create a new [`ResponseDefaultsConfig`] object, with a [`Config`] object.
-    pub fn from_config(config: &Config) -> Self {
+    pub const fn from_config(config: &Config) -> Self {
         Self::new(
             ResponseDefaultsConfig::from_config(config),
             ResponseSizeLimitsConfig::from_config(config),
@@ -78,7 +78,7 @@ impl ResponseDefaultsConfig {
     /// From config.
     ///
     /// Create a new [`ResponseDefaultsConfig`] object, with a [`Config`] object.
-    pub fn from_config(config: &Config) -> Self {
+    pub const fn from_config(config: &Config) -> Self {
         let size_limits = config.size_limits();
 
         Self::new(
@@ -146,7 +146,7 @@ impl ResponseSizeLimitsConfig {
     /// From config.
     ///
     /// Create a new [`ResponseDefaultsConfig`] object, with a [`Config`] object.
-    pub fn from_config(config: &Config) -> Self {
+    pub const fn from_config(config: &Config) -> Self {
         let size_limits = config.size_limits();
         Self::new(
             size_limits.minimum_expiry_hours(),
@@ -231,13 +231,13 @@ impl ResponsePaste {
         let token_value: Option<String> = { token.map(|t| t.token().expose_secret().to_string()) };
 
         Self::new(
-            paste.id,
+            *paste.id(),
             token_value,
-            paste.creation,
-            paste.edited,
-            paste.expiry,
-            paste.views,
-            paste.max_views,
+            *paste.creation(),
+            paste.edited().copied(),
+            paste.expiry().copied(),
+            paste.views(),
+            paste.max_views(),
             documents,
         )
     }

--- a/src/rest/config.rs
+++ b/src/rest/config.rs
@@ -48,7 +48,7 @@ pub fn generate_router(config: &Config) -> Router<App> {
 }
 
 async fn get_config(State(app): State<App>) -> Result<Response, AppError> {
-    let response_config = ResponseConfig::from_config(&app.config);
+    let response_config = ResponseConfig::from_config(app.config());
 
     Ok((StatusCode::OK, Json(response_config)).into_response())
 }

--- a/src/rest/document.rs
+++ b/src/rest/document.rs
@@ -129,17 +129,17 @@ async fn get_document(
     State(app): State<App>,
     Path((paste_id, document_id)): Path<(Snowflake, Snowflake)>,
 ) -> Result<Response, AppError> {
-    let document = Document::fetch(app.database.pool(), document_id)
+    let document = Document::fetch(app.database().pool(), &document_id)
         .await?
         .ok_or_else(|| AppError::NotFound("Document not found.".to_string()))?;
 
-    if document.paste_id != paste_id {
+    if document.paste_id() != &paste_id {
         return Err(AppError::BadRequest(
             "The document ID does not belong to that paste.".to_string(),
         ));
     }
 
-    Paste::add_view(app.database.pool(), paste_id).await?;
+    Paste::add_view(app.database().pool(), &paste_id).await?;
 
     Ok((StatusCode::OK, Json(document)).into_response())
 }
@@ -166,7 +166,7 @@ async fn post_document(
     token: Token,
     body: Bytes,
 ) -> Result<Response, AppError> {
-    let mut paste = validate_paste(&app.database, paste_id, Some(token)).await?;
+    let mut paste = validate_paste(app.database(), &paste_id, Some(token)).await?;
 
     let document_type = {
         if let Some(TypedHeader(content_type)) = content_type {
@@ -182,19 +182,19 @@ async fn post_document(
         }
     };
 
+    let name = content_disposition.filename().unwrap_or("unknown");
+
     let document = Document::new(
         Snowflake::generate()?,
-        paste.id,
-        document_type,
-        content_disposition
-            .filename()
-            .unwrap_or_else(|| "unknown".to_string()),
+        *paste.id(),
+        &document_type,
+        name,
         body.len(),
     );
 
-    document_limits(&app.config, &document)?;
+    document_limits(app.config(), &document)?;
 
-    let mut transaction = app.database.pool().begin().await?;
+    let mut transaction = app.database().pool().begin().await?;
 
     paste.set_edited();
 
@@ -202,9 +202,9 @@ async fn post_document(
 
     document.insert(transaction.as_mut()).await?;
 
-    total_document_limits(&mut transaction, &app.config, paste_id).await?;
+    total_document_limits(&mut transaction, app.config(), &paste_id).await?;
 
-    app.s3.create_document(&document, body.clone()).await?;
+    app.s3().create_document(&document, body).await?;
 
     transaction.commit().await?;
 
@@ -238,7 +238,7 @@ async fn patch_document(
     token: Token,
     body: Bytes,
 ) -> Result<Response, AppError> {
-    let mut paste = validate_paste(&app.database, paste_id, Some(token)).await?;
+    let mut paste = validate_paste(app.database(), &paste_id, Some(token)).await?;
 
     let document_type = {
         if let Some(TypedHeader(content_type)) = content_type {
@@ -254,17 +254,17 @@ async fn patch_document(
         }
     };
 
-    let mut document = Document::fetch(app.database.pool(), document_id)
+    let mut document = Document::fetch(app.database().pool(), &document_id)
         .await?
         .ok_or_else(|| AppError::NotFound("Document not found.".to_string()))?;
 
-    let mut transaction = app.database.pool().begin().await?;
+    let mut transaction = app.database().pool().begin().await?;
 
     paste.set_edited();
 
     paste.update(transaction.as_mut()).await?;
 
-    document.set_document_type(document_type);
+    document.set_doc_type(&document_type);
 
     document.set_size(body.len());
 
@@ -272,15 +272,15 @@ async fn patch_document(
         document.set_name(filename);
     }
 
-    document_limits(&app.config, &document)?;
+    document_limits(app.config(), &document)?;
 
     document.update(transaction.as_mut()).await?;
 
-    total_document_limits(&mut transaction, &app.config, paste_id).await?;
+    total_document_limits(&mut transaction, app.config(), &paste_id).await?;
 
-    app.s3.delete_document(document.generate_path()).await?;
+    app.s3().delete_document(document.generate_path()).await?;
 
-    app.s3.create_document(&document, body.clone()).await?;
+    app.s3().create_document(&document, body).await?;
 
     transaction.commit().await?;
 
@@ -311,7 +311,7 @@ async fn delete_document(
     }
 
     let total_document_count =
-        Document::fetch_total_document_count(app.database.pool(), paste_id).await?;
+        Document::fetch_total_document_count(app.database().pool(), &paste_id).await?;
 
     if total_document_count <= 1 {
         return Err(AppError::BadRequest(
@@ -319,7 +319,7 @@ async fn delete_document(
         ));
     }
 
-    if !Document::delete(app.database.pool(), document_id).await? {
+    if !Document::delete(app.database().pool(), &document_id).await? {
         return Err(AppError::NotFound(
             "The document was not found.".to_string(),
         ));
@@ -336,12 +336,12 @@ struct ContentDisposition {
 
 impl ContentDisposition {
     #[allow(dead_code)]
-    pub fn disposition(&self) -> String {
-        self.disposition.clone()
+    pub fn disposition(&self) -> &str {
+        &self.disposition
     }
 
-    pub fn filename(&self) -> Option<String> {
-        self.filename.clone()
+    pub fn filename(&self) -> Option<&str> {
+        self.filename.as_deref()
     }
 }
 

--- a/tests/models_authentication_test.rs
+++ b/tests/models_authentication_test.rs
@@ -33,7 +33,7 @@ fn test_fetch(pool: PgPool) {
     let token_string =
         "NTE3ODE1MzA0MzU0Mjg0NjAx.MTc0NzgxNjA1NA==.zYXUmCXIcnlvtAxJNJsUaDvRD".to_string();
 
-    let token = Token::fetch(db.pool(), token_string.clone())
+    let token = Token::fetch(db.pool(), &token_string)
         .await
         .expect("Could not fetch a token.")
         .expect("No token found.");
@@ -54,7 +54,7 @@ fn test_fetch(pool: PgPool) {
 fn test_fetch_missing(pool: PgPool) {
     let db = Database::from_pool(pool);
 
-    let token = Token::fetch(db.pool(), "missing.token".to_string())
+    let token = Token::fetch(db.pool(), "missing.token")
         .await
         .expect("Could not fetch a token.");
 
@@ -75,7 +75,7 @@ fn test_insert(pool: PgPool) {
         .await
         .expect("Failed to insert paste token");
 
-    let result_token = Token::fetch(db.pool(), token.expose_secret().to_string())
+    let result_token = Token::fetch(db.pool(), token.expose_secret())
         .await
         .expect("Failed to fetch value from database.")
         .expect("No paste token was found.");
@@ -92,19 +92,18 @@ fn test_insert(pool: PgPool) {
 fn test_delete(pool: PgPool) {
     let db = Database::from_pool(pool);
 
-    let token_string =
-        "NTE3ODE1MzA0MzU0Mjg0NjAx.MTc0NzgxNjA1NA==.zYXUmCXIcnlvtAxJNJsUaDvRD".to_string();
+    let token_string = "NTE3ODE1MzA0MzU0Mjg0NjAx.MTc0NzgxNjA1NA==.zYXUmCXIcnlvtAxJNJsUaDvRD";
 
-    Token::fetch(db.pool(), token_string.clone())
+    Token::fetch(db.pool(), token_string)
         .await
         .expect("Could not fetch a token.")
         .expect("No token found.");
 
-    Token::delete(db.pool(), token_string.clone())
+    Token::delete(db.pool(), token_string)
         .await
         .expect("Failed to delete value from database.");
 
-    let paste_token = Token::fetch(db.pool(), token_string.clone())
+    let paste_token = Token::fetch(db.pool(), token_string)
         .await
         .expect("Could not fetch a token.");
 

--- a/tests/models_document_test.rs
+++ b/tests/models_document_test.rs
@@ -13,30 +13,21 @@ use sqlx::PgPool;
 fn test_getters() {
     let paste_id = Snowflake::new(123);
     let document_id = Snowflake::new(456);
-    let document_type = String::from("example/document");
-    let name = String::from("test.document");
+    let doc_type = "example/document";
+    let name = "test.document";
     let size = 329;
 
-    let document = Document::new(
-        document_id,
-        paste_id,
-        document_type.clone(),
-        name.clone(),
-        size,
-    );
+    let document = Document::new(document_id, paste_id, doc_type, name, size);
 
-    assert!(document.id == document_id, "Mismatched document ID.");
+    assert!(document.id() == &document_id, "Mismatched document ID.");
 
-    assert!(document.paste_id == paste_id, "Mismatched paste ID.");
+    assert!(document.paste_id() == &paste_id, "Mismatched paste ID.");
 
-    assert!(
-        document.document_type == document_type,
-        "Mismatched document type."
-    );
+    assert!(document.doc_type() == doc_type, "Mismatched document type.");
 
-    assert!(document.name == name, "Mismatched name.");
+    assert!(document.name() == name, "Mismatched name.");
 
-    assert!(document.size == size, "Mismatched size.");
+    assert!(document.size() == size, "Mismatched size.");
 
     assert!(
         document.generate_url("http://example.com")
@@ -51,114 +42,88 @@ fn test_getters() {
 }
 
 #[test]
-fn test_set_document_type() {
+fn test_set_doc_type() {
     let paste_id = Snowflake::new(123);
     let document_id = Snowflake::new(456);
-    let document_type = String::from("example/document");
-    let name = String::from("test.document");
+    let doc_type = "example/document";
+    let name = "test.document";
     let size = 6908;
 
-    let mut document = Document::new(
-        document_id,
-        paste_id,
-        document_type.clone(),
-        name.clone(),
-        size,
-    );
+    let mut document = Document::new(document_id, paste_id, doc_type, name, size);
+
+    assert_eq!(document.doc_type(), doc_type, "Mismatched document type.");
+
+    let new_doc_type = String::from("new/document");
+
+    document.set_doc_type(&new_doc_type);
+
+    assert_eq!(document.id(), &document_id, "Mismatched document ID.");
+
+    assert_eq!(document.paste_id(), &paste_id, "Mismatched paste ID.");
 
     assert_eq!(
-        document.document_type, document_type,
+        document.doc_type(),
+        new_doc_type,
         "Mismatched document type."
     );
 
-    let new_document_type = String::from("new/document");
+    assert_eq!(document.name(), name, "Mismatched name.");
 
-    document.set_document_type(new_document_type.clone());
-
-    assert_eq!(document.id, document_id, "Mismatched document ID.");
-
-    assert_eq!(document.paste_id, paste_id, "Mismatched paste ID.");
-
-    assert_eq!(
-        document.document_type, new_document_type,
-        "Mismatched document type."
-    );
-
-    assert_eq!(document.name, name, "Mismatched name.");
-
-    assert_eq!(document.size, size, "Mismatched size.");
+    assert_eq!(document.size(), size, "Mismatched size.");
 }
 
 #[test]
 fn test_set_name() {
     let paste_id = Snowflake::new(123);
     let document_id = Snowflake::new(456);
-    let document_type = String::from("example/document");
-    let name = String::from("test.document");
+    let doc_type = "example/document";
+    let name = "test.document";
     let size = 6908;
 
-    let mut document = Document::new(
-        document_id,
-        paste_id,
-        document_type.clone(),
-        name.clone(),
-        size,
-    );
+    let mut document = Document::new(document_id, paste_id, doc_type, name, size);
 
-    assert_eq!(document.name, name, "Mismatched name.");
+    assert_eq!(document.name(), name, "Mismatched name.");
 
     let new_name = String::from("cool.new");
 
-    document.set_name(new_name.clone());
+    document.set_name(&new_name);
 
-    assert_eq!(document.id, document_id, "Mismatched document ID.");
+    assert_eq!(document.id(), &document_id, "Mismatched document ID.");
 
-    assert_eq!(document.paste_id, paste_id, "Mismatched paste ID.");
+    assert_eq!(document.paste_id(), &paste_id, "Mismatched paste ID.");
 
-    assert_eq!(
-        document.document_type, document_type,
-        "Mismatched document type."
-    );
+    assert_eq!(document.doc_type(), doc_type, "Mismatched document type.");
 
-    assert_eq!(document.name, new_name, "Mismatched name.");
+    assert_eq!(document.name(), new_name, "Mismatched name.");
 
-    assert_eq!(document.size, size, "Mismatched size.");
+    assert_eq!(document.size(), size, "Mismatched size.");
 }
 
 #[test]
 fn test_set_size() {
     let paste_id = Snowflake::new(123);
     let document_id = Snowflake::new(456);
-    let document_type = String::from("example/document");
-    let name = String::from("test.document");
+    let doc_type = "example/document";
+    let name = "test.document";
     let size = 6908;
 
-    let mut document = Document::new(
-        document_id,
-        paste_id,
-        document_type.clone(),
-        name.clone(),
-        size,
-    );
+    let mut document = Document::new(document_id, paste_id, doc_type, name, size);
 
-    assert_eq!(document.size, size, "Mismatched size.");
+    assert_eq!(document.size(), size, "Mismatched size.");
 
     let new_size = 39485;
 
     document.set_size(new_size);
 
-    assert_eq!(document.id, document_id, "Mismatched document ID.");
+    assert_eq!(document.id(), &document_id, "Mismatched document ID.");
 
-    assert_eq!(document.paste_id, paste_id, "Mismatched paste ID.");
+    assert_eq!(document.paste_id(), &paste_id, "Mismatched paste ID.");
 
-    assert_eq!(
-        document.document_type, document_type,
-        "Mismatched document type."
-    );
+    assert_eq!(document.doc_type(), doc_type, "Mismatched document type.");
 
-    assert_eq!(document.name, name, "Mismatched name.");
+    assert_eq!(document.name(), name, "Mismatched name.");
 
-    assert_eq!(document.size, new_size, "Mismatched size.");
+    assert_eq!(document.size(), new_size, "Mismatched size.");
 }
 
 #[sqlx::test(fixtures("pastes", "documents"))]
@@ -167,27 +132,28 @@ fn test_fetch(pool: PgPool) {
 
     let document_id = Snowflake::new(517_815_304_354_284_701);
 
-    let document = Document::fetch(db.pool(), document_id)
+    let document = Document::fetch(db.pool(), &document_id)
         .await
         .expect("Failed to fetch value from database.")
         .expect("No document was found.");
 
-    assert_eq!(document.id, document_id, "Mismatched document ID.");
+    assert_eq!(document.id(), &document_id, "Mismatched document ID.");
 
     assert_eq!(
-        document.paste_id,
-        Snowflake::new(517_815_304_354_284_601),
+        document.paste_id(),
+        &Snowflake::new(517_815_304_354_284_601),
         "Mismatched paste ID."
     );
 
     assert_eq!(
-        document.document_type, "plain/text",
+        document.doc_type(),
+        "plain/text",
         "Mismatched document type."
     );
 
-    assert_eq!(document.name, "cool.txt", "Mismatched document type.");
+    assert_eq!(document.name(), "cool.txt", "Mismatched document type.");
 
-    assert_eq!(document.size, 811, "Mismatched document size.");
+    assert_eq!(document.size(), 811, "Mismatched document size.");
 }
 
 #[sqlx::test(fixtures("pastes", "documents"))]
@@ -197,7 +163,7 @@ fn test_fetch_missing(pool: PgPool) {
     let document_id = Snowflake::new(456);
 
     assert!(
-        Document::fetch(db.pool(), document_id)
+        Document::fetch(db.pool(), &document_id)
             .await
             .expect("Failed to fetch value from database.")
             .is_none()
@@ -211,23 +177,24 @@ fn test_fetch_with_paste(pool: PgPool) {
     let paste_id = Snowflake::new(517_815_304_354_284_601);
     let document_id = Snowflake::new(517_815_304_354_284_701);
 
-    let document = Document::fetch_with_paste(db.pool(), paste_id, document_id)
+    let document = Document::fetch_with_paste(db.pool(), &paste_id, &document_id)
         .await
         .expect("Failed to fetch value from database.")
         .expect("No document was found.");
 
-    assert_eq!(document.id, document_id, "Mismatched document ID.");
+    assert_eq!(document.id(), &document_id, "Mismatched document ID.");
 
-    assert_eq!(document.paste_id, paste_id, "Mismatched paste ID.");
+    assert_eq!(document.paste_id(), &paste_id, "Mismatched paste ID.");
 
     assert_eq!(
-        document.document_type, "plain/text",
+        document.doc_type(),
+        "plain/text",
         "Mismatched document type."
     );
 
-    assert_eq!(document.name, "cool.txt", "Mismatched document type.");
+    assert_eq!(document.name(), "cool.txt", "Mismatched document type.");
 
-    assert_eq!(document.size, 811, "Mismatched document size.");
+    assert_eq!(document.size(), 811, "Mismatched document size.");
 }
 
 #[sqlx::test(fixtures("pastes", "documents"))]
@@ -238,7 +205,7 @@ fn test_fetch_with_paste_missing(pool: PgPool) {
     let document_id = Snowflake::new(456);
 
     assert!(
-        Document::fetch_with_paste(db.pool(), paste_id, document_id)
+        Document::fetch_with_paste(db.pool(), &paste_id, &document_id)
             .await
             .expect("Failed to fetch value from database.")
             .is_none()
@@ -251,7 +218,7 @@ fn test_fetch_all(pool: PgPool) {
 
     let paste_id = Snowflake::new(517_815_304_354_284_603);
 
-    let documents = Document::fetch_all(db.pool(), paste_id)
+    let documents = Document::fetch_all(db.pool(), &paste_id)
         .await
         .expect("Failed to fetch value from database.");
 
@@ -261,25 +228,34 @@ fn test_fetch_all(pool: PgPool) {
     );
 
     assert!(
-        documents[0].id == Snowflake::new(517_815_304_354_284_704),
+        documents[0].id() == &Snowflake::new(517_815_304_354_284_704),
         "Mismatched document ID 1."
     );
 
-    assert!(documents[0].paste_id == paste_id, "Mismatched paste ID 1.");
+    assert!(
+        documents[0].paste_id() == &paste_id,
+        "Mismatched paste ID 1."
+    );
 
     assert!(
-        documents[1].id == Snowflake::new(517_815_304_354_284_705),
+        documents[1].id() == &Snowflake::new(517_815_304_354_284_705),
         "Mismatched document ID 2."
     );
 
-    assert!(documents[1].paste_id == paste_id, "Mismatched paste ID 2.");
+    assert!(
+        documents[1].paste_id() == &paste_id,
+        "Mismatched paste ID 2."
+    );
 
     assert!(
-        documents[2].id == Snowflake::new(517_815_304_354_284_706),
+        documents[2].id() == &Snowflake::new(517_815_304_354_284_706),
         "Mismatched document ID 3."
     );
 
-    assert!(documents[2].paste_id == paste_id, "Mismatched paste ID 3.");
+    assert!(
+        documents[2].paste_id() == &paste_id,
+        "Mismatched paste ID 3."
+    );
 }
 
 #[sqlx::test(fixtures("pastes", "documents"))]
@@ -289,7 +265,7 @@ fn test_fetch_all_missing(pool: PgPool) {
     let paste_id = Snowflake::new(456);
 
     assert!(
-        Document::fetch_all(db.pool(), paste_id)
+        Document::fetch_all(db.pool(), &paste_id)
             .await
             .expect("Failed to fetch value from database.")
             .is_empty()
@@ -302,40 +278,31 @@ fn test_insert(pool: PgPool) {
 
     let paste_id = Snowflake::new(517_815_304_354_284_601);
     let document_id = Snowflake::new(456);
-    let document_type = String::from("example/document");
-    let name = String::from("test.document");
+    let doc_type = "example/document";
+    let name = "test.document";
     let size = 475;
 
-    let document = Document::new(
-        document_id,
-        paste_id,
-        document_type.clone(),
-        name.clone(),
-        size,
-    );
+    let document = Document::new(document_id, paste_id, doc_type, name, size);
 
     document
         .insert(db.pool())
         .await
         .expect("Failed to insert paste");
 
-    let result = Document::fetch(db.pool(), document_id)
+    let result = Document::fetch(db.pool(), &document_id)
         .await
         .expect("Failed to fetch value from database.")
         .expect("No document was found.");
 
-    assert_eq!(result.id, document_id, "Mismatched document ID.");
+    assert_eq!(result.id(), &document_id, "Mismatched document ID.");
 
-    assert_eq!(result.paste_id, paste_id, "Mismatched paste ID.");
+    assert_eq!(result.paste_id(), &paste_id, "Mismatched paste ID.");
 
-    assert_eq!(
-        result.document_type, document_type,
-        "Mismatched document type."
-    );
+    assert_eq!(result.doc_type(), doc_type, "Mismatched document type.");
 
-    assert_eq!(result.name, name, "Mismatched document type.");
+    assert_eq!(result.name(), name, "Mismatched document type.");
 
-    assert_eq!(result.size, size);
+    assert_eq!(result.size(), size);
 }
 
 #[sqlx::test(fixtures("pastes", "documents"))]
@@ -344,37 +311,38 @@ fn test_update(pool: PgPool) {
 
     let document_id = Snowflake::new(517_815_304_354_284_701);
 
-    let mut document = Document::fetch(db.pool(), document_id)
+    let mut document = Document::fetch(db.pool(), &document_id)
         .await
         .expect("Failed to fetch value from database.")
         .expect("Document was not found.");
 
-    assert_eq!(document.id, document_id, "Mismatched document ID.");
+    assert_eq!(document.id(), &document_id, "Mismatched document ID.");
 
     assert_eq!(
-        document.paste_id,
-        Snowflake::new(517_815_304_354_284_601),
+        document.paste_id(),
+        &Snowflake::new(517_815_304_354_284_601),
         "Mismatched paste ID."
     );
 
     assert_eq!(
-        document.document_type, "plain/text",
+        document.doc_type(),
+        "plain/text",
         "Mismatched document type."
     );
 
-    assert_eq!(document.name, "cool.txt", "Mismatched document type.");
+    assert_eq!(document.name(), "cool.txt", "Mismatched document type.");
 
-    assert_eq!(document.size, 811, "Mismatched document size.");
+    assert_eq!(document.size(), 811, "Mismatched document size.");
 
-    let new_document_type = String::from("example/new");
+    let new_doc_type = String::from("example/new");
 
     let new_name = String::from("test_new_name");
 
     let new_size = 83247;
 
-    document.set_document_type(new_document_type.clone());
+    document.set_doc_type(&new_doc_type);
 
-    document.set_name(new_name.clone());
+    document.set_name(&new_name);
 
     document.set_size(new_size);
 
@@ -383,27 +351,40 @@ fn test_update(pool: PgPool) {
         .await
         .expect("Failed to update paste.");
 
-    let result_document = Document::fetch(db.pool(), document_id)
+    let result_document = Document::fetch(db.pool(), &document_id)
         .await
         .expect("Failed to fetch value from database.")
         .expect("Document was not found.");
 
-    assert_eq!(result_document.id, document_id, "Mismatched document ID.");
+    assert_eq!(
+        result_document.id(),
+        &document_id,
+        "Mismatched document ID."
+    );
 
     assert_eq!(
-        result_document.paste_id,
-        Snowflake::new(517_815_304_354_284_601),
+        result_document.paste_id(),
+        &Snowflake::new(517_815_304_354_284_601),
         "Mismatched paste ID."
     );
 
     assert_eq!(
-        document.document_type, new_document_type,
+        document.doc_type(),
+        new_doc_type,
         "Mismatched document type."
     );
 
-    assert_eq!(result_document.name, new_name, "Mismatched document type.");
+    assert_eq!(
+        result_document.name(),
+        new_name,
+        "Mismatched document type."
+    );
 
-    assert_eq!(result_document.size, new_size, "Mismatched document size.");
+    assert_eq!(
+        result_document.size(),
+        new_size,
+        "Mismatched document size."
+    );
 }
 
 #[sqlx::test(fixtures("pastes", "documents"))]
@@ -412,16 +393,16 @@ fn test_delete(pool: PgPool) {
 
     let document_id = Snowflake::new(517_815_304_354_284_701);
 
-    Document::fetch(db.pool(), document_id)
+    Document::fetch(db.pool(), &document_id)
         .await
         .expect("Could not fetch a document.")
         .expect("No token found.");
 
-    Document::delete(db.pool(), document_id)
+    Document::delete(db.pool(), &document_id)
         .await
         .expect("Failed to delete value from database.");
 
-    let paste_token = Document::fetch(db.pool(), document_id)
+    let paste_token = Document::fetch(db.pool(), &document_id)
         .await
         .expect("Could not fetch a token.");
 
@@ -478,8 +459,8 @@ fn test_document_limits() {
     let document = Document::new(
         Snowflake::new(456),
         Snowflake::new(123),
-        "text/plain".to_string(),
-        "test_doc.txt".to_string(),
+        "text/plain",
+        "test_doc.txt",
         489,
     );
 
@@ -508,8 +489,8 @@ fn test_document_limits_errors(#[case] config: Config, #[case] expected: &str) {
     let document = Document::new(
         Snowflake::new(456),
         Snowflake::new(123),
-        "text/plain".to_string(),
-        "test_doc.txt".to_string(),
+        "text/plain",
+        "test_doc.txt",
         489,
     );
 
@@ -572,7 +553,7 @@ async fn test_total_document_limits(pool: PgPool) {
     total_document_limits(
         &mut transaction,
         &make_total_document_limits_config(1, 1, 10, 10_000_000),
-        Snowflake::new(517_815_304_354_284_601),
+        &Snowflake::new(517_815_304_354_284_601),
     )
     .await
     .expect("An error occurred.");
@@ -612,7 +593,7 @@ async fn test_total_document_limits_errors(
     let error = total_document_limits(
         &mut transaction,
         &config,
-        Snowflake::new(517_815_304_354_284_602),
+        &Snowflake::new(517_815_304_354_284_602),
     )
     .await
     .expect_err("No error received.");

--- a/tests/models_paste_test.rs
+++ b/tests/models_paste_test.rs
@@ -22,15 +22,15 @@ fn test_getters() {
         Some(1000),
     );
 
-    assert_eq!(paste.id, paste_id, "Mismatched paste ID.");
+    assert_eq!(paste.id(), &paste_id, "Mismatched paste ID.");
 
-    assert_eq!(paste.edited, Some(edited), "Mismatched edited.");
+    assert_eq!(paste.edited(), Some(&edited), "Mismatched edited.");
 
-    assert!(paste.expiry == Some(expiry), "Mismatched expiry.");
+    assert!(paste.expiry() == Some(&expiry), "Mismatched expiry.");
 
-    assert_eq!(paste.views, 567, "Mismatched views.");
+    assert_eq!(paste.views(), 567, "Mismatched views.");
 
-    assert_eq!(paste.max_views, Some(1000), "Mismatched max views.");
+    assert_eq!(paste.max_views(), Some(1000), "Mismatched max views.");
 }
 
 #[test]
@@ -41,14 +41,14 @@ fn test_set_edited() {
 
     let mut paste = Paste::new(paste_id, creation, None, Some(expiry), 567, Some(1000));
 
-    assert_eq!(paste.edited, None, "Mismatched edited.");
+    assert_eq!(paste.edited(), None, "Mismatched edited.");
 
     let current = OffsetDateTime::now_utc();
     paste.set_edited();
 
-    assert_eq!(paste.id, paste_id, "Mismatched paste ID.");
+    assert_eq!(paste.id(), &paste_id, "Mismatched paste ID.");
 
-    let paste_edited = paste.edited.expect("Edited was not found.");
+    let paste_edited = paste.edited().expect("Edited was not found.");
 
     assert_eq!(
         paste_edited.date(),
@@ -61,11 +61,11 @@ fn test_set_edited() {
         "Mismatched edited HMS."
     );
 
-    assert_eq!(paste.expiry, Some(expiry), "Mismatched expiry.");
+    assert_eq!(paste.expiry(), Some(&expiry), "Mismatched expiry.");
 
-    assert_eq!(paste.views, 567, "Mismatched views.");
+    assert_eq!(paste.views(), 567, "Mismatched views.");
 
-    assert_eq!(paste.max_views, Some(1000), "Mismatched max views.");
+    assert_eq!(paste.max_views(), Some(1000), "Mismatched max views.");
 }
 
 #[test]
@@ -76,19 +76,19 @@ fn test_set_expiry() {
 
     let mut paste = Paste::new(paste_id, creation, None, Some(expiry), 567, Some(1000));
 
-    assert_eq!(paste.expiry, Some(expiry), "Mismatched expiry.");
+    assert_eq!(paste.expiry(), Some(&expiry), "Mismatched expiry.");
 
     paste.set_expiry(None);
 
-    assert_eq!(paste.id, paste_id, "Mismatched paste ID.");
+    assert_eq!(paste.id(), &paste_id, "Mismatched paste ID.");
 
-    assert_eq!(paste.edited, None, "Mismatched edited.");
+    assert_eq!(paste.edited(), None, "Mismatched edited.");
 
-    assert!(paste.expiry.is_none(), "Mismatched expiry.");
+    assert!(paste.expiry().is_none(), "Mismatched expiry.");
 
-    assert_eq!(paste.views, 567, "Mismatched views.");
+    assert_eq!(paste.views(), 567, "Mismatched views.");
 
-    assert_eq!(paste.max_views, Some(1000), "Mismatched max views.");
+    assert_eq!(paste.max_views(), Some(1000), "Mismatched max views.");
 }
 
 #[sqlx::test(fixtures("pastes"))]
@@ -103,22 +103,22 @@ fn test_fetch(pool: PgPool) {
     let expiry =
         OffsetDateTime::from_unix_timestamp(172_800).expect("failed to generate expiry timestamp.");
 
-    let paste = Paste::fetch(db.pool(), paste_id)
+    let paste = Paste::fetch(db.pool(), &paste_id)
         .await
         .expect("Failed to fetch value from database.")
         .expect("No paste was found.");
 
-    assert_eq!(paste.id, paste_id, "Mismatched paste ID.");
+    assert_eq!(paste.id(), &paste_id, "Mismatched paste ID.");
 
-    assert_eq!(paste.creation, creation, "Mismatched creation time.");
+    assert_eq!(paste.creation(), &creation, "Mismatched creation time.");
 
-    assert_eq!(paste.edited, Some(edited), "Mismatched edited time.");
+    assert_eq!(paste.edited(), Some(&edited), "Mismatched edited time.");
 
-    assert_eq!(paste.expiry, Some(expiry), "Mismatched expiry time.");
+    assert_eq!(paste.expiry(), Some(&expiry), "Mismatched expiry time.");
 
-    assert_eq!(paste.views, 567, "Mismatched views.");
+    assert_eq!(paste.views(), 567, "Mismatched views.");
 
-    assert_eq!(paste.max_views, Some(1000), "Mismatched max views.");
+    assert_eq!(paste.max_views(), Some(1000), "Mismatched max views.");
 }
 
 #[sqlx::test]
@@ -128,7 +128,7 @@ fn test_fetch_missing(pool: PgPool) {
     let id = Snowflake::new(123);
 
     assert!(
-        Paste::fetch(db.pool(), id)
+        Paste::fetch(db.pool(), &id)
             .await
             .expect("Failed to fetch value from database.")
             .is_none()
@@ -141,12 +141,12 @@ fn test_fetch_between(pool: PgPool) {
 
     let results = Paste::fetch_between(
         db.pool(),
-        OffsetDateTime::new_utc(
+        &OffsetDateTime::new_utc(
             Date::from_calendar_date(1970, time::Month::January, 2)
                 .expect("Failed to build date start."),
             Time::from_hms(0, 0, 0).expect("Failed to build time start."),
         ),
-        OffsetDateTime::new_utc(
+        &OffsetDateTime::new_utc(
             Date::from_calendar_date(1970, time::Month::January, 4)
                 .expect("Failed to build date end."),
             Time::from_hms(0, 0, 0).expect("Failed to build time end."),
@@ -158,11 +158,11 @@ fn test_fetch_between(pool: PgPool) {
     assert_eq!(results.len(), 1, "Not enough or too many results received.");
 
     assert_eq!(
-        results[0].expiry,
-        Some(OffsetDateTime::from_unix_timestamp(172_800).expect("Failed to build result time.")),
+        results[0].expiry(),
+        Some(&OffsetDateTime::from_unix_timestamp(172_800).expect("Failed to build result time.")),
         "Invalid expiry. Expected: {:?}, Received: {:?}",
         Some(OffsetDateTime::from_unix_timestamp(172_800).expect("Failed to build result time.")),
-        results[0].expiry,
+        results[0].expiry(),
     );
 }
 
@@ -172,12 +172,12 @@ fn test_fetch_between_missing(pool: PgPool) {
 
     let results = Paste::fetch_between(
         db.pool(),
-        OffsetDateTime::new_utc(
+        &OffsetDateTime::new_utc(
             Date::from_calendar_date(2000, time::Month::January, 1)
                 .expect("Failed to build date start."),
             Time::from_hms(0, 0, 0).expect("Failed to build time start."),
         ),
-        OffsetDateTime::new_utc(
+        &OffsetDateTime::new_utc(
             Date::from_calendar_date(2001, time::Month::January, 1)
                 .expect("Failed to build date end."),
             Time::from_hms(0, 0, 0).expect("Failed to build time end."),
@@ -215,22 +215,22 @@ fn test_insert(pool: PgPool) {
         .await
         .expect("Failed to insert paste");
 
-    let result = Paste::fetch(db.pool(), paste_id)
+    let result = Paste::fetch(db.pool(), &paste_id)
         .await
         .expect("Failed to fetch value from database.")
         .expect("No paste was found.");
 
-    assert_eq!(result.id, paste_id, "Mismatched paste ID.");
+    assert_eq!(result.id(), &paste_id, "Mismatched paste ID.");
 
-    assert_eq!(result.creation, creation, "Mismatched creation time.");
+    assert_eq!(result.creation(), &creation, "Mismatched creation time.");
 
-    assert_eq!(result.edited, Some(edited), "Mismatched edited time.");
+    assert_eq!(result.edited(), Some(&edited), "Mismatched edited time.");
 
-    assert_eq!(result.expiry, Some(expiry), "Mismatched expiry time.");
+    assert_eq!(result.expiry(), Some(&expiry), "Mismatched expiry time.");
 
-    assert_eq!(paste.views, 53489, "Mismatched views.");
+    assert_eq!(paste.views(), 53489, "Mismatched views.");
 
-    assert_eq!(paste.max_views, Some(100_000), "Mismatched max views.");
+    assert_eq!(paste.max_views(), Some(100_000), "Mismatched max views.");
 }
 
 #[sqlx::test(fixtures("pastes"))]
@@ -238,23 +238,23 @@ fn test_update(pool: PgPool) {
     let db = Database::from_pool(pool);
 
     let paste_id = Snowflake::new(517_815_304_354_284_601);
-    let mut paste = Paste::fetch(db.pool(), paste_id)
+    let mut paste = Paste::fetch(db.pool(), &paste_id)
         .await
         .expect("Failed to fetch value from database.")
         .expect("No paste was found.");
 
-    assert_eq!(paste.id, paste_id, "Mismatched paste ID.");
+    assert_eq!(paste.id(), &paste_id, "Mismatched paste ID.");
 
     assert_eq!(
-        paste.edited,
-        Some(OffsetDateTime::from_unix_timestamp(86400).expect("failed to generate timestamp.")),
+        paste.edited(),
+        Some(&OffsetDateTime::from_unix_timestamp(86400).expect("failed to generate timestamp.")),
         "Mismatched edited time."
     );
 
     assert_eq!(
-        paste.expiry,
+        paste.expiry(),
         Some(
-            OffsetDateTime::from_unix_timestamp(172_800)
+            &OffsetDateTime::from_unix_timestamp(172_800)
                 .expect("Failed to build expected timestamp.")
         ),
         "Mismatched expiry time."
@@ -271,12 +271,12 @@ fn test_update(pool: PgPool) {
         .await
         .expect("Failed to update paste.");
 
-    let result = Paste::fetch(db.pool(), paste_id)
+    let result = Paste::fetch(db.pool(), &paste_id)
         .await
         .expect("Failed to fetch value from database.")
         .expect("No paste was found.");
 
-    let paste_edited = paste.edited.expect("Edited was not found.");
+    let paste_edited = paste.edited().expect("Edited was not found.");
 
     assert_eq!(
         paste_edited.date(),
@@ -289,7 +289,7 @@ fn test_update(pool: PgPool) {
         "Mismatched edited HMS."
     );
 
-    assert!(result.expiry.is_none(), "Mismatched expiry time.");
+    assert!(result.expiry().is_none(), "Mismatched expiry time.");
 }
 
 #[sqlx::test(fixtures("pastes"))]
@@ -297,27 +297,27 @@ fn test_add_view(pool: PgPool) {
     let db = Database::from_pool(pool);
 
     let paste_id = Snowflake::new(517_815_304_354_284_601);
-    let paste = Paste::fetch(db.pool(), paste_id)
+    let paste = Paste::fetch(db.pool(), &paste_id)
         .await
         .expect("Failed to fetch value from database.")
         .expect("No paste was found.");
 
-    assert_eq!(paste.id, paste_id, "Mismatched paste ID.");
+    assert_eq!(paste.id(), &paste_id, "Mismatched paste ID.");
 
-    assert_eq!(paste.views, 567, "Mismatched views count.");
+    assert_eq!(paste.views(), 567, "Mismatched views count.");
 
-    let value = Paste::add_view(db.pool(), paste_id)
+    let value = Paste::add_view(db.pool(), &paste_id)
         .await
         .expect("Failed to add view to paste.");
 
     assert_eq!(value, 568, "Mismatched view count.");
 
-    let result = Paste::fetch(db.pool(), paste_id)
+    let result = Paste::fetch(db.pool(), &paste_id)
         .await
         .expect("Failed to fetch value from database.")
         .expect("No paste was found.");
 
-    assert_eq!(result.views, 568, "Mismatched views count.");
+    assert_eq!(result.views(), 568, "Mismatched views count.");
 }
 
 #[sqlx::test(fixtures("pastes"))]
@@ -326,16 +326,16 @@ fn test_delete(pool: PgPool) {
 
     let paste_id = Snowflake::new(517_815_304_354_284_601);
 
-    Paste::fetch(db.pool(), paste_id)
+    Paste::fetch(db.pool(), &paste_id)
         .await
         .expect("Failed to fetch value from database.")
         .expect("No paste was found.");
 
-    Paste::delete(db.pool(), paste_id)
+    Paste::delete(db.pool(), &paste_id)
         .await
         .expect("Failed to delete value from database.");
 
-    let result = Paste::fetch(db.pool(), paste_id)
+    let result = Paste::fetch(db.pool(), &paste_id)
         .await
         .expect("Failed to fetch value from database.");
 


### PR DESCRIPTION
Add speedups for compilation and internal resources like removing unused deserialize and serialize statements, as well as removing redundant .clone() operations.